### PR TITLE
Ensure module name is a str. Not always the case!

### DIFF
--- a/bilby/core/utils/log.py
+++ b/bilby/core/utils/log.py
@@ -73,6 +73,6 @@ def loaded_modules_dict():
     module_names = list(sys.modules.keys())
     vdict = {}
     for key in module_names:
-        if "." not in key:
+        if "." not in str(key):
             vdict[key] = str(getattr(sys.modules[key], "__version__", "N/A"))
     return vdict


### PR DESCRIPTION
Just a tiny fix to the log module. In some cases, the module name isn't a string type. This causes an error:
```
TypeError: argument of type 'module' is not iterable
```
This is easily fixed with just a little `str` wrap with no loss in functionality.