### PR TITLE
BUG: fix typo in ln_i0

### DIFF
--- a/bilby/gw/utils.py
+++ b/bilby/gw/utils.py
@@ -1038,7 +1038,7 @@ def ln_i0(value):
     array-like:
         The natural logarithm of the bessel function
     """
-    return np.log(i0e(value)) + value
+    return np.log(i0e(value)) + np.abs(value)
 
 
 def calculate_time_to_merger(frequency, mass_1, mass_2, chi=0, safety=1.1):

--- a/test/gw/utils_test.py
+++ b/test/gw/utils_test.py
@@ -274,5 +274,11 @@ class TestSkyFrameConversion(unittest.TestCase):
         self.assertGreaterEqual(ks_2samp(self.samples["dec"], decs).pvalue, 0.01)
 
 
+def test_ln_i0_mathces_scipy():
+    from scipy.special import i0
+    values = np.linspace(-10, 10, 101)
+    assert max(abs(gwutils.ln_i0(values) - np.log(i0(values)))) < 1e-10
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR fixes a long-standing typo in the definition of `ln_i0`.

This is also intended as a test of a system to get changes on GitHub back to git.ligo.org