### PR TITLE
MAINT: remove unneeded global statement

### DIFF
--- a/bilby/core/sampler/base_sampler.py
+++ b/bilby/core/sampler/base_sampler.py
@@ -57,7 +57,6 @@ def _initialize_global_variables(
     Store a global copy of the likelihood, priors, and search keys for
     multiprocessing.
     """
-    global _sampling_convenience_dump
     _sampling_convenience_dump.likelihood = likelihood
     _sampling_convenience_dump.priors = priors
     _sampling_convenience_dump.search_parameter_keys = search_parameter_keys


### PR DESCRIPTION
I've been seeing a bunch of pre-commit failures like https://github.com/bilby-dev/bilby/actions/runs/15570808614/job/43845972057?pr=877.

This PR fixes that by removing a `global` statement. It looks like this is not needed, I did some tests with a simple example and things work well. The CI should give it a real test in context.