### PR TITLE
BUG: fix new ValueError for numpy>=2.1 in slabspike.py

### DIFF
--- a/bilby/core/prior/slabspike.py
+++ b/bilby/core/prior/slabspike.py
@@ -137,6 +137,7 @@ class SlabSpikePrior(Prior):
         original_is_number = isinstance(val, Number)
         res = self.slab.prob(val) * self.slab_fraction
         res = np.atleast_1d(res)
+        val = np.atleast_1d(val)
         res[np.where(val == self.spike_location)] = np.inf
         if original_is_number:
             try:
@@ -161,6 +162,7 @@ class SlabSpikePrior(Prior):
         original_is_number = isinstance(val, Number)
         res = self.slab.ln_prob(val) + np.log(self.slab_fraction)
         res = np.atleast_1d(res)
+        val = np.atleast_1d(val)
         res[np.where(val == self.spike_location)] = np.inf
         if original_is_number:
             try:
@@ -186,6 +188,7 @@ class SlabSpikePrior(Prior):
         """
         res = self.slab.cdf(val) * self.slab_fraction
         res = np.atleast_1d(res)
+        val = np.atleast_1d(val)
         indices_above_spike = np.where(val > self.spike_location)[0]
         res[indices_above_spike] += self.spike_height
         return res


### PR DESCRIPTION
This PR fixes a problem with `numpy>=2.1`, which makes the test `slabspike_test.py` failing. Error message is 
```
ValueError: Calling nonzero on 0d arrays is not allowed. Use np.atleast_1d(scalar).nonzero() instead. If the context of this error is of the form `arr[nonzero(cond)]`, just use `arr[cond]`.
```
Steps to repoduce: running `pytest -k slabspike_test.py` with `numpy>=2.1`


<details>
  <summary>full failing test log</summary>
  
```
test/core/prior/slabspike_test.py .........FFF.....F.F....                                                                                                                                                   [100%]

===================================================================================================== FAILURES =====================================================================================================
_____________________________________________________________________________________ TestSlabSpikeClasses.test_cdf_at_maximum _____________________________________________________________________________________

self = <test.core.prior.slabspike_test.TestSlabSpikeClasses testMethod=test_cdf_at_maximum>

    def test_cdf_at_maximum(self):
        for slab_spike in self.slab_spikes:
            expected = 1
>           actual = slab_spike.cdf(slab_spike.maximum)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

test/core/prior/slabspike_test.py:169:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = SlabSpikePrior(slab=Uniform(minimum=0.4, maximum=2.4, name=None, latex_label=None, unit=None, boundary=None), spike_location=1.5, spike_height=0.3), val = 2.4

    def cdf(self, val):
        """ Return the CDF of the prior.
        This calls to the slab CDF and adds a discrete step
        at the spike location.

        Parameters
        ==========
        val: Union[float, int, array_like]

        Returns
        =======
        array_like: CDF value of val

        """
        res = self.slab.cdf(val) * self.slab_fraction
        res = np.atleast_1d(res)
>       indices_above_spike = np.where(val > self.spike_location)[0]
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       ValueError: Calling nonzero on 0d arrays is not allowed. Use np.atleast_1d(scalar).nonzero() instead. If the context of this error is of the form `arr[nonzero(cond)]`, just use `arr[cond]`.

bilby/core/prior/slabspike.py:189: ValueError
_____________________________________________________________________________________ TestSlabSpikeClasses.test_cdf_at_minimum _____________________________________________________________________________________

self = <test.core.prior.slabspike_test.TestSlabSpikeClasses testMethod=test_cdf_at_minimum>

    def test_cdf_at_minimum(self):
        for slab_spike in self.slab_spikes:
            expected = 0
>           actual = slab_spike.cdf(slab_spike.minimum)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

test/core/prior/slabspike_test.py:163:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = SlabSpikePrior(slab=Uniform(minimum=0.4, maximum=2.4, name=None, latex_label=None, unit=None, boundary=None), spike_location=1.5, spike_height=0.3), val = 0.4

    def cdf(self, val):
        """ Return the CDF of the prior.
        This calls to the slab CDF and adds a discrete step
        at the spike location.

        Parameters
        ==========
        val: Union[float, int, array_like]

        Returns
        =======
        array_like: CDF value of val

        """
        res = self.slab.cdf(val) * self.slab_fraction
        res = np.atleast_1d(res)
>       indices_above_spike = np.where(val > self.spike_location)[0]
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       ValueError: Calling nonzero on 0d arrays is not allowed. Use np.atleast_1d(scalar).nonzero() instead. If the context of this error is of the form `arr[nonzero(cond)]`, just use `arr[cond]`.

bilby/core/prior/slabspike.py:189: ValueError
______________________________________________________________________________________ TestSlabSpikeClasses.test_cdf_at_spike ______________________________________________________________________________________

self = <test.core.prior.slabspike_test.TestSlabSpikeClasses testMethod=test_cdf_at_spike>

    def test_cdf_at_spike(self):
        for slab, slab_spike in zip(self.slabs, self.slab_spikes):
            expected = slab.cdf(self.spike_loc) * slab_spike.slab_fraction
>           actual = slab_spike.cdf(self.spike_loc)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

test/core/prior/slabspike_test.py:150:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = SlabSpikePrior(slab=Uniform(minimum=0.4, maximum=2.4, name=None, latex_label=None, unit=None, boundary=None), spike_location=1.5, spike_height=0.3), val = 1.5

    def cdf(self, val):
        """ Return the CDF of the prior.
        This calls to the slab CDF and adds a discrete step
        at the spike location.

        Parameters
        ==========
        val: Union[float, int, array_like]

        Returns
        =======
        array_like: CDF value of val

        """
        res = self.slab.cdf(val) * self.slab_fraction
        res = np.atleast_1d(res)
>       indices_above_spike = np.where(val > self.spike_location)[0]
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       ValueError: Calling nonzero on 0d arrays is not allowed. Use np.atleast_1d(scalar).nonzero() instead. If the context of this error is of the form `arr[nonzero(cond)]`, just use `arr[cond]`.

bilby/core/prior/slabspike.py:189: ValueError
____________________________________________________________________________________ TestSlabSpikeClasses.test_ln_prob_on_spike ____________________________________________________________________________________

self = <test.core.prior.slabspike_test.TestSlabSpikeClasses testMethod=test_ln_prob_on_spike>

    def test_ln_prob_on_spike(self):
        for slab_spike in self.slab_spikes:
>           self.assertEqual(np.inf, slab_spike.ln_prob(self.spike_loc))
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

test/core/prior/slabspike_test.py:123:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = SlabSpikePrior(slab=Uniform(minimum=0.4, maximum=2.4, name=None, latex_label=None, unit=None, boundary=None), spike_location=1.5, spike_height=0.3), val = 1.5

    def ln_prob(self, val):
        """Return the Log prior probability of val.
        Returns np.inf for the spike location

        Parameters
        ==========
        val: Union[float, int, array_like]

        Returns
        =======
        array_like: Prior probability of val
        """
        original_is_number = isinstance(val, Number)
        res = self.slab.ln_prob(val) + np.log(self.slab_fraction)
        res = np.atleast_1d(res)
>       res[np.where(val == self.spike_location)] = np.inf
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       ValueError: Calling nonzero on 0d arrays is not allowed. Use np.atleast_1d(scalar).nonzero() instead. If the context of this error is of the form `arr[nonzero(cond)]`, just use `arr[cond]`.

bilby/core/prior/slabspike.py:164: ValueError
_____________________________________________________________________________________ TestSlabSpikeClasses.test_prob_on_spike ______________________________________________________________________________________

self = <test.core.prior.slabspike_test.TestSlabSpikeClasses testMethod=test_prob_on_spike>

    def test_prob_on_spike(self):
        for slab_spike in self.slab_spikes:
>           self.assertEqual(np.inf, slab_spike.prob(self.spike_loc))
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

test/core/prior/slabspike_test.py:113:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = SlabSpikePrior(slab=Uniform(minimum=0.4, maximum=2.4, name=None, latex_label=None, unit=None, boundary=None), spike_location=1.5, spike_height=0.3), val = 1.5

    def prob(self, val):
        """Return the prior probability of val.
        Returns np.inf for the spike location

        Parameters
        ==========
        val: Union[float, int, array_like]

        Returns
        =======
        array_like: Prior probability of val
        """
        original_is_number = isinstance(val, Number)
        res = self.slab.prob(val) * self.slab_fraction
        res = np.atleast_1d(res)
>       res[np.where(val == self.spike_location)] = np.inf
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       ValueError: Calling nonzero on 0d arrays is not allowed. Use np.atleast_1d(scalar).nonzero() instead. If the context of this error is of the form `arr[nonzero(cond)]`, just use `arr[cond]`.

bilby/core/prior/slabspike.py:140: ValueError
```

</details>