### PR TITLE
TST: mark whitened strain tests as flaky

### DIFF
--- a/test/gw/detector/interferometer_test.py
+++ b/test/gw/detector/interferometer_test.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import lal
 import lalsimulation
+import pytest
 from shutil import rmtree
 
 import numpy as np
@@ -594,6 +595,7 @@ class TestInterferometerAntennaPatternAgainstLAL(unittest.TestCase):
                 self.assertAlmostEqual(std, 0.0, places=10)
 
 
+@pytest.mark.flaky(reruns=3, only_rerun=["AssertionError"])
 class TestInterferometerWhitenedStrain(unittest.TestCase):
     def setUp(self):
         self.duration = 64


### PR DESCRIPTION
I noticed the tests that check the properties of whitened strain data can randomly fail for some random seeds, see e.g. https://github.com/bilby-dev/bilby/actions/runs/17268550864/job/49006677033. This PR marks them as flaky so they should be re-run if they fail.