### PR TITLE
BUG: Update sampler_init_kwargs for dynestyv3 compatibility

### DIFF
--- a/bilby/core/sampler/dynesty.py
+++ b/bilby/core/sampler/dynesty.py
@@ -296,7 +296,7 @@ class Dynesty(NestedSampler):
             elif kwargs["bound"] == "live":
                 logger.info(
                     "Live-point based bound method requested with dynesty sample "
-                    f"'{sample}', overwriting to 'multi'"
+                    f"'{kwargs['sample']}', overwriting to 'multi'"
                 )
                 kwargs["bound"] = "multi"
         return kwargs


### PR DESCRIPTION
Adjust sampler initialization arguments for new dynesty API. This will fix the failures seen in https://github.com/bilby-dev/bilby/actions/runs/18467619522/job/52613334363?pr=940.