### PR TITLE
ENH: add npool_post_process

### DIFF
--- a/bilby/core/sampler/__init__.py
+++ b/bilby/core/sampler/__init__.py
@@ -352,7 +352,7 @@ def run_sampler(
     if getattr(result, "_posterior", None) is None:
         if npool_post_process is None:
 
-            for key in Sampler.npool_post_process_keys:
+            for key in Sampler.npool_equiv_kwargs:
                 if key in kwargs:
                     npool_post_process = kwargs[key]
                     break


### PR DESCRIPTION
Add an `npool_post_process`.

This allows the user to configure how many processes are used for post-processing independently of how many are used for sampling. Whilst making this change, I also changed the code so aliases for npool also trigger the parallelized post-processing.

I also remove an old unused argument.
