### PR TITLE
BUG: Fix calls of Likelihood.noise_log_likelihood with parameters

### DIFF
--- a/bilby/core/likelihood.py
+++ b/bilby/core/likelihood.py
@@ -172,7 +172,7 @@ class ZeroLikelihood(Likelihood):
     def log_likelihood(self, parameters=None):
         return 0
 
-    def noise_log_likelihood(self, parameters=None):
+    def noise_log_likelihood(self):
         return 0
 
     def __getattr__(self, name):
@@ -654,9 +654,9 @@ class JointLikelihood(Likelihood):
         """ This is just the sum of the log likelihoods of all parts of the joint likelihood"""
         return sum([likelihood.log_likelihood(parameters=parameters) for likelihood in self.likelihoods])
 
-    def noise_log_likelihood(self, parameters=None):
+    def noise_log_likelihood(self):
         """ This is just the sum of the noise likelihoods of all parts of the joint likelihood"""
-        return sum([likelihood.noise_log_likelihood(parameters=parameters) for likelihood in self.likelihoods])
+        return sum([likelihood.noise_log_likelihood() for likelihood in self.likelihoods])
 
 
 def function_to_celerite_mean_model(func):


### PR DESCRIPTION
JointLikelihood and ZeroLikelihood have accepted a "parameters"-argument that is not accepted elsewhere in the lnoise_og_likelihood method and 