### PR TITLE
BUG: Make sure all parameters are passed to fisher matrix calculation

### DIFF
--- a/bilby/bilby_mcmc/proposals.py
+++ b/bilby/bilby_mcmc/proposals.py
@@ -825,8 +825,10 @@ class FisherMatrixProposal(AdaptiveGaussianProposal):
             fmp = FisherMatrixPosteriorEstimator(
                 likelihood, priors, parameters=self.parameters, fd_eps=self.fd_eps
             )
+            parameters = {key: priors[key].peak for key in priors.fixed_keys}
+            parameters.update(sample.dict)
             try:
-                self.iFIM = fmp.calculate_iFIM(sample.dict)
+                self.iFIM = fmp.calculate_iFIM(parameters)
             except (RuntimeError, ValueError, np.linalg.LinAlgError) as e:
                 logger.warning(f"FisherMatrixProposal failed with {e}")
                 if hasattr(self, "iFIM") is False:


### PR DESCRIPTION
@GregoryAshton this tracks back to the `FisherMatrixPosteriorEstimator`, I opted to update the parameters that are passed to the FMPE, rather than allowing it to just take a subset. I think this is more inline with the recent changes to the likelihood.

```python
Traceback (most recent call last):
  File "/Users/ct6081/software/bilby/examples/gw_examples/injection_examples/fast_tutorial.py", line 117, in <module>
    result = bilby.run_sampler(
             ^^^^^^^^^^^^^^^^^^
  File "/Users/ct6081/software/bilby/bilby/core/sampler/__init__.py", line 314, in run_sampler
    result = sampler.run_sampler()
             ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ct6081/software/bilby/bilby/core/sampler/base_sampler.py", line 101, in wrapped
    output = method(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ct6081/software/bilby/bilby/bilby_mcmc/sampler.py", line 254, in run_sampler
    self.draw()
  File "/Users/ct6081/software/bilby/bilby/bilby_mcmc/sampler.py", line 341, in draw
    self.ptsampler.step_all_chains()
  File "/Users/ct6081/software/bilby/bilby/bilby_mcmc/sampler.py", line 812, in step_all_chains
    self.sampler_list[ii] = sampler.step()
                            ^^^^^^^^^^^^^^
  File "/Users/ct6081/software/bilby/bilby/bilby_mcmc/sampler.py", line 1276, in step
    prop, log_factor = proposal(
                       ^^^^^^^^^
  File "/Users/ct6081/software/bilby/bilby/bilby_mcmc/proposals.py", line 139, in __call__
    sample, log_factor = self.propose(chain, likelihood, priors)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ct6081/software/bilby/bilby/bilby_mcmc/proposals.py", line 829, in propose
    self.iFIM = fmp.calculate_iFIM(sample.dict)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ct6081/software/bilby/bilby/core/fisher.py", line 60, in calculate_iFIM
    FIM = self.calculate_FIM(sample)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ct6081/software/bilby/bilby/core/fisher.py", line 88, in calculate_FIM
    FIM[ii, jj] = -self.get_second_order_derivative(sample, ii_key, jj_key)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ct6081/software/bilby/bilby/core/fisher.py", line 94, in get_second_order_derivative
    return self.get_finite_difference_xx(sample, ii)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ct6081/software/bilby/bilby/core/fisher.py", line 105, in get_finite_difference_xx
    loglp = self.log_likelihood(p)
            ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ct6081/software/bilby/bilby/core/fisher.py", line 57, in log_likelihood
    return _safe_likelihood_call(self.likelihood, parameters)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ct6081/software/bilby/bilby/core/likelihood.py", line 46, in _safe_likelihood_call
    logl = method(parameters=parameters)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ct6081/software/bilby/bilby/gw/likelihood/base.py", line 892, in log_likelihood
    return self.log_likelihood_ratio(parameters=parameters) + self.noise_log_likelihood()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ct6081/software/bilby/bilby/gw/likelihood/base.py", line 414, in log_likelihood_ratio
    self.waveform_generator.frequency_domain_strain(parameters)
  File "/Users/ct6081/software/bilby/bilby/gw/waveform_generator.py", line 138, in frequency_domain_strain
    return self._calculate_strain(model=self.frequency_domain_source_model,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ct6081/software/bilby/bilby/gw/waveform_generator.py", line 195, in _calculate_strain
    parameters = self._format_parameters(parameters)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ct6081/software/bilby/bilby/gw/waveform_generator.py", line 272, in _format_parameters
    new_parameters.pop(key)
KeyError: 'a_2'
```

Closes #1011 