### PR TITLE
CI: Modify publish.yml to support TestPyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,8 @@ name: Publish Python distribution to PyPI
 
 on:
   - push
+    branches:
+      - main
   - release
 
 jobs:


### PR DESCRIPTION
Updated the GitHub Actions workflow to trigger on push events and added a new job for publishing to TestPyPI.

Closes #978 