### PR TITLE
BUG: fix triangular interferometer coordinates

### DIFF
--- a/bilby/gw/detector/networks.py
+++ b/bilby/gw/detector/networks.py
@@ -358,6 +358,8 @@ class TriangularInterferometer(InterferometerList):
         if isinstance(maximum_frequency, float) or isinstance(maximum_frequency, int):
             maximum_frequency = [maximum_frequency] * 3
 
+        brng = 90 - xarm_azimuth
+
         for ii in range(3):
             self.append(
                 Interferometer(
@@ -376,29 +378,23 @@ class TriangularInterferometer(InterferometerList):
                 )
             )
 
+            phi1 = np.radians(latitude)
+            phi2 = np.arcsin(
+                np.sin(phi1) * np.cos(length * 1e3 / utils.radius_of_earth) +
+                np.cos(phi1) * np.sin(length * 1e3 / utils.radius_of_earth) * np.cos(np.radians(brng))
+            )
+            latitude = np.degrees(phi2)
+
+            lam1 = np.radians(longitude)
+            lam2 = lam1 + np.arctan2(
+                np.sin(np.radians(brng)) * np.sin(length * 1e3 / utils.radius_of_earth) * np.cos(phi1),
+                np.cos(length * 1e3 / utils.radius_of_earth) - np.sin(phi1) * np.sin(phi2)
+            )
+            longitude = np.degrees(lam2)
+
+            brng += 240
             xarm_azimuth += 240
             yarm_azimuth += 240
-
-            latitude += (
-                np.arctan(
-                    length
-                    * np.sin(xarm_azimuth * np.pi / 180)
-                    * 1e3
-                    / utils.radius_of_earth
-                )
-                * 180
-                / np.pi
-            )
-            longitude += (
-                np.arctan(
-                    length
-                    * np.cos(xarm_azimuth * np.pi / 180)
-                    * 1e3
-                    / utils.radius_of_earth
-                )
-                * 180
-                / np.pi
-            )
 
 
 def get_empty_interferometer(name):

--- a/test/gw/detector/networks_test.py
+++ b/test/gw/detector/networks_test.py
@@ -387,7 +387,7 @@ class TriangularInterferometerTest(unittest.TestCase):
         for pair in list(combinations(self.triangular_ifo, 2)):
             delta_lat = np.radians(pair[1].latitude - pair[0].latitude)
             delta_long = np.radians(pair[1].longitude - pair[0].longitude)
-            pair_a = a(delta_lat, delta_long, pair[0].latitude, pair[1].latitude)
+            pair_a = a(delta_lat, delta_long, np.radians(pair[0].latitude), np.radians(pair[1].latitude))
             pair_c = c(pair_a)
             distance = bilby.core.utils.radius_of_earth * pair_c
             self.assertAlmostEqual(distance / 1000, pair[0].length, delta=1)


### PR DESCRIPTION
Hi,

I believe I have found two bugs in the implementation of the triangular-shaped interferometer.
The first issue concerns [this test](https://github.com/bilby-dev/bilby/blob/main/test/gw/detector/networks_test.py#L361), where the angles passed to [this function](https://github.com/bilby-dev/bilby/blob/main/test/gw/detector/networks_test.py#L390) should be given in radians, as also stated in [1]. However, in the current implementation, the last two latitude values are passed in degrees.
When the angles are passed correctly, the test fails. For example, if the position of the first vertex is set to `(40.516°, 9.416°)` with `x_arm_azimuth = 70.5674°`, the distances between the vertices are:

ET-1 ↔️ ET-2: 9.06 km
ET-1 ↔️ ET-3: 9.76 km
ET-2 ↔️ ET-3: 7.70 km

I believe this test failure is due to an incorrect implementation of the functions updating [latitude](https://github.com/bilby-dev/bilby/blob/main/bilby/gw/detector/networks.py#L382) and [longitude](https://github.com/bilby-dev/bilby/blob/main/bilby/gw/detector/networks.py#L392), which differ from those provided in [1]:

```
const φ2 = Math.asin( Math.sin(φ1)*Math.cos(d/R) +
Math.cos(φ1)*Math.sin(d/R)*Math.cos(brng) );
const λ2 = λ1 + Math.atan2(Math.sin(brng)*Math.sin(d/R)*Math.cos(φ1),
Math.cos(d/R)-Math.sin(φ1)*Math.sin(φ2));
```

The only difference to keep in mind is the definition of the bearing angle: in bilby it is defined counterclockwise from east, whereas in [1] it is clockwise from north. This leads to the following conversion:

```
brng = 90 - x_arm_azimuth
```

Using the above expressions, the coordinates are recovered correctly.
I also include a map illustrating this result: the blue dots represent the incorrect coordinates, while the red dots show the corrected ones.

<img width="758" height="750" alt="ET_map" src="https://github.com/user-attachments/assets/a5f06465-2eb9-4862-bc26-6eaca9e5121e" />

I believe this also resolves [this issue](https://git.ligo.org/lscsoft/bilby/-/issues/655), since, when using the Virgo site coordinates as the starting point, it becomes possible to recover the positions of the other two vertices correctly, as defined in [LAL](https://lscsoft.docs.ligo.org/lalsuite/lal/_l_a_l_detectors_8h_source.html#l00602).

I don’t think this bug has any practical effect on previously obtained parameter estimation results.

<img width="1953" height="1497" alt="CheckFix_log_likelihood" src="https://github.com/user-attachments/assets/b5b83be2-f22b-4bee-9698-2048c4354682" />

I’m opening this pull request to contribute to fixing this bug.

I am tagging a few people who might be interested in the matter [@jacopo.tissino](https://github.com/jacopo.tissino) [@sylvia.biscoveanu](https://github.com/sylvia.biscoveanu)

Thanks a lot in advance.
Kind regards,
Filippo

[1] [https://www.movable-type.co.uk/scripts/latlong.html](https://www.movable-type.co.uk/scripts/latlong.html)