### PR TITLE
Copilot/fix typo in gwsignalwaveformgenerator

### DIFF
--- a/bilby/gw/waveform_generator.py
+++ b/bilby/gw/waveform_generator.py
@@ -356,7 +356,7 @@ class GWSignalWaveformGenerator(WaveformGenerator):
 
         return (
             f"{self.__class__.__name__}(duration={self.duration}, "
-            f"sampling_frequency={self.duration}, start_time={self.start_time}, "
+            f"sampling_frequency={self.sampling_frequency}, start_time={self.start_time}, "
             f"parameter_conversion={param_conv_name}, "
             f"waveform_arguments={self.waveform_arguments}, "
             f"spinning={self.spinning}, eccentric={self.eccentric}, tidal={self.tidal}"

--- a/test/gw/waveform_generator_test.py
+++ b/test/gw/waveform_generator_test.py
@@ -925,6 +925,16 @@ class TestGWSignalGenerator(unittest.TestCase):
 
         assert wfg.frequency_domain_strain(parameters) is None
 
+    def test_repr(self):
+        wfg = self.get_wfgen()
+        repr_str = repr(wfg)
+        # Check that the repr contains the correct sampling_frequency value
+        # This test specifically checks that sampling_frequency is not incorrectly set to duration
+        assert f"sampling_frequency={wfg.sampling_frequency}" in repr_str
+        assert f"duration={wfg.duration}" in repr_str
+        # Ensure sampling_frequency and duration have different values in our test
+        assert wfg.sampling_frequency != wfg.duration
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This was an attempt to have copilot fix #1017, it looks like branch protections means that copilot cannot directly open PRs for us.

See https://github.com/ColmTalbot/bilby/pull/2 for the PR copilot opened.