### PR TITLE
BUG: Fix handling of contour-kwargs for multiple corner plots

### DIFF
--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -2111,7 +2111,7 @@ def plot_multiple(results, filename=None, labels=None, colours=None,
         `corner_labels` input).
         However, `show_titles` and `truths` are ignored since they would be
         ambiguous on such a plot. The keyword arguments `contour_kwargs["linestyles"]`,
-        `contour_kwargs['colors']`, `hist_kwargs["linestyle"]`, `color` and 
+        `contour_kwargs['colors']`, `hist_kwargs["linestyle"]`, `color` and
         `hist_kwargs["color"]` are overwritten with the values provided in the
         `colours` and `linestyles` inputs or by the default styles.
     evidences: bool, optional


### PR DESCRIPTION
Hi everyone,

At the moment, it is not possible to pass `contour_kwargs` to the `plot_multiple` corner-plot function because `plot_multiple` passes its own `contour_kwargs` to `result.plot_corner` even if it was provided as a keyword argument.
This little PR fixes this. The PR also removes an intermediate plotting call, which was made redundant by https://github.com/bilby-dev/bilby/pull/946.


