### PR TITLE
Change probability initialization to use np.ones_like

### DIFF
--- a/bilby/core/prior/dict.py
+++ b/bilby/core/prior/dict.py
@@ -592,7 +592,7 @@ class PriorDict(dict):
             return ln_prob
         else:
             if isinstance(ln_prob, float):
-                if self.evaluate_constraints(sample):
+                if np.all(self.evaluate_constraints(sample)):
                     return ln_prob + np.log(ratio)
                 else:
                     return -np.inf


### PR DESCRIPTION
`prior.sample()` seems to always trigger the warning:

```
bilby WARNING : Prior sampling efficiency is very low, please verify its validity.
```

when using a prior with keys, without Constraints, and requesting more than 1000 samples. E.g.:

```python
import bilby
prior=bilby.core.prior.PriorDict({'param1':bilby.core.prior.Uniform(minimum=5, maximum=50)})
samples=prior.sample(1001)
```

(And for some parallel workflows keeps triggering the warning).

This seems to stem from `evaluate_constraints()` which defaults to returning a single `1` when there aren't Constraints (instead of an array of ones), which is then used to count the number of valid samples (`n_valid_samples`), returning always 1, and thus triggering the warning once one asks for more than 1000 samples (`if n_tested >= 1e3 and efficiency < 1e-3:` in `check_efficiency()`).

The solution proposed here is to replace `evaluate_constraints()`'s default `prob` to be an array of ones like the first values in `out_samples`. 