### PR TITLE
FEAT: Subclass of GWSignalWaveformGenerator for eccentric waveforms

### DIFF
--- a/bilby/gw/waveform_generator.py
+++ b/bilby/gw/waveform_generator.py
@@ -581,8 +581,9 @@ class GWSignalWaveformGenerator(WaveformGenerator):
 
 class EccentricGWSignalWaveformGenerator(GWSignalWaveformGenerator):
     """
-    Subclass that initializes an eccentric GW Signal Waveform Generator.
-    See documentation of `GWSignalWaveformGenerator` for more information
+    Subclass that initializes an eccentric GWSignal Waveform Generator.
+    Equivalent to `GWSignalWaveformGenerator` with `eccentric=True`.
+    See documentation of `GWSignalWaveformGenerator` for more information.
     """
 
     def __init__(self, **kwargs):

--- a/bilby/gw/waveform_generator.py
+++ b/bilby/gw/waveform_generator.py
@@ -579,6 +579,16 @@ class GWSignalWaveformGenerator(WaveformGenerator):
         return self._all_parameters.difference(self.defaults.keys())
 
 
+class EccentricGWSignalWaveformGenerator(GWSignalWaveformGenerator):
+    """
+    Subclass that initializes an eccentric GW Signal Waveform Generator.
+    See documentation of `GWSignalWaveformGenerator` for more information
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(eccentric=True, **kwargs)
+
+
 def _try_waveform_call(func, parameters, generator, catch_waveform_errors):
     try:
         return func(parameters, generator)


### PR DESCRIPTION
Adds a subclass of GWSignalWaveformGenerator for eccentric waveforms.

I realize that avoiding subclassing/writing source models was one of the reasons we moved away from the old way of calling waveforms. I see these subclasses as "convenience functions", and since it doesn't duplicate a lot of code I am in favour of adding them. But I can also see arguments to the contrary.