### PR TITLE
BUG: Exclude infinite values from gradient check tau list

### DIFF
--- a/bilby/core/sampler/ptemcee.py
+++ b/bilby/core/sampler/ptemcee.py
@@ -915,6 +915,8 @@ def check_iteration(
     nsteps_to_check = ci.autocorr_tau * np.max([2 * GRAD_WINDOW_LENGTH, tau_int])
     lower_tau_index = np.max([0, len(tau_list) - nsteps_to_check])
     check_taus = np.array(tau_list[lower_tau_index:])
+    # gradient check requires finite estimates
+    check_taus = check_taus[~np.any(np.isinf(check_taus), axis=1)]
     if not np.any(np.isnan(check_taus)) and check_taus.shape[0] > GRAD_WINDOW_LENGTH:
         gradient_tau = get_max_gradient(
             check_taus, axis=0, window_length=GRAD_WINDOW_LENGTH


### PR DESCRIPTION
Filter out infinite estimates from check_taus for gradient check to fix pipeline failures, e.g., https://github.com/bilby-dev/bilby/actions/runs/21145268346/job/60809211967?pr=1034.

This is needed after https://github.com/scipy/scipy/commit/94c351af88c35e3c94df3d74182d5057b0833fd4 (scipy==1.17.0)