### PR TITLE
BUG: Fix path for LinAlgError in exception handling

### DIFF
--- a/bilby/core/sampler/dynesty.py
+++ b/bilby/core/sampler/dynesty.py
@@ -1007,7 +1007,7 @@ class Dynesty(NestedSampler):
                 fig.savefig(filename)
             except (
                 RuntimeError,
-                np.linalg.linalg.LinAlgError,
+                np.linalg.LinAlgError,
                 ValueError,
                 OverflowError,
             ) as e:
@@ -1033,7 +1033,7 @@ class Dynesty(NestedSampler):
                 fig.savefig(filename)
             except (
                 RuntimeError,
-                np.linalg.linalg.LinAlgError,
+                np.linalg.LinAlgError,
                 ValueError,
                 OverflowError,
             ) as e:
@@ -1055,7 +1055,7 @@ class Dynesty(NestedSampler):
                 plt.savefig(filename)
             except (
                 RuntimeError,
-                np.linalg.linalg.LinAlgError,
+                np.linalg.LinAlgError,
                 ValueError,
                 OverflowError,
             ) as e:


### PR DESCRIPTION
I noticed failures of this line with numpy 2.4.1, so I suspect this has been deprecated for a while and finally removed.