### PR TITLE
CI: fix triggers for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,11 @@
 name: Publish Python distribution to PyPI
 
 on:
-  - push
+  push:
     branches:
       - main
-  - release
+  release:
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
The changes in https://github.com/bilby-dev/bilby/pull/1014 introduced a couple of typos that broke the publish workflow.