### PR TITLE
BUG: Fix sampler_kwargs mutation in dynesty3_utils

### DIFF
--- a/bilby/core/sampler/dynesty3_utils.py
+++ b/bilby/core/sampler/dynesty3_utils.py
@@ -1,4 +1,3 @@
-import os
 import warnings
 from collections import namedtuple
 
@@ -337,12 +336,9 @@ class ACTTrackingEnsembleWalk(BaseEnsembleSampler):
     def sample(args):
         cache = ACTTrackingEnsembleWalk._cache
         if args.kwargs.get("rebuild", False):
-            logger.debug(
-                f"Force rebuilding cache with {len(cache)} remaining on {os.getpid()}"
-            )
+            logger.debug(f"Force rebuilding cache with {len(cache)}.")
             cache.clear()
         if len(cache) == 0:
-            logger.debug(f"Rebuilding cache on {os.getpid()}")
             ACTTrackingEnsembleWalk.build_cache(args)
 
         while len(cache) > 0 and cache[0][2] < args.loglstar:


### PR DESCRIPTION
I noticed that there was bad efficiency running the ACT walk in parallel because the chains were getting out of sync which it turns out is because we were mutating a dictionary.