### PR TITLE
DEP: remove ability to use parameters as state

### DIFF
--- a/bilby/core/fisher.py
+++ b/bilby/core/fisher.py
@@ -3,8 +3,6 @@ import pandas as pd
 import scipy.linalg
 from scipy.optimize import minimize
 
-from .likelihood import _safe_likelihood_call
-
 
 class FisherMatrixPosteriorEstimator(object):
     def __init__(self, likelihood, priors, parameters=None, fd_eps=1e-6, n_prior_samples=100):
@@ -47,7 +45,7 @@ class FisherMatrixPosteriorEstimator(object):
             self.prior_width_dict[key] = width
 
     def log_likelihood(self, sample):
-        return _safe_likelihood_call(self.likelihood, sample)
+        return self.likelihood.log_likelihood(sample)
 
     def calculate_iFIM(self, sample):
         FIM = self.calculate_FIM(sample)

--- a/bilby/core/grid.py
+++ b/bilby/core/grid.py
@@ -3,7 +3,6 @@ import os
 
 import numpy as np
 
-from .likelihood import _safe_likelihood_call
 from .prior import Prior, PriorDict
 from .utils import (
     logtrapzexp, check_directory_exists_and_if_not_mkdir, logger,
@@ -313,9 +312,7 @@ class Grid(object):
             current_point = tuple([[int(np.where(
                 parameters[name] ==
                 self.sample_points[name])[0])] for name in self.parameter_names])
-            self._ln_likelihood[current_point] = _safe_likelihood_call(
-                self.likelihood, parameters
-            )
+            self._ln_likelihood[current_point] = self.likelihood.log_likelihood(parameters)
         else:
             name = self.parameter_names[dimension]
             for ii in range(self._ln_likelihood.shape[dimension]):

--- a/bilby/core/likelihood.py
+++ b/bilby/core/likelihood.py
@@ -9,86 +9,10 @@ from scipy.stats import multivariate_normal
 
 from .utils import infer_parameters_from_function, infer_args_from_function_except_n_args, logger
 
-PARAMETERS_AS_STATE = os.environ.get("BILBY_ALLOW_PARAMETERS_AS_STATE", "WARN")
-for msg in [
-    "No parameters provided in likelihood call",
-    "Using parameters as state",
-    "Parameter attribute queried",
-    "Settings non-trivial"
-]:
-    warnings.filterwarnings("once", message=msg)
-
-
-def set_parameters_as_state(level):
-    global PARAMETERS_AS_STATE
-
-    level = str(level).upper()
-    if level not in ["TRUE", "FALSE", "WARN"]:
-        raise ValueError("Allowed levels for parameters as state are 'TRUE', 'FALSE', and 'WARN'")
-    PARAMETERS_AS_STATE = level
-
-
-def _fallback_to_parameters(obj, parameters):
-
-    if parameters is None:
-        msg = (
-            f"No parameters provided in likelihood call, falling back to values stored in {obj}. "
-            "This is deprecated behaviour  and will be removed in Bilby version 3. "
-            "See https://bilby-dev.github.io/bilby/parameters for more details."
-        )
-        if PARAMETERS_AS_STATE == "FALSE":
-            raise LikelihoodParameterError(msg)
-        elif PARAMETERS_AS_STATE == "WARN":
-            warnings.warn(msg, FutureWarning)
-        else:
-            logger.debug(msg)
-        parameters = copy.deepcopy(obj.parameters)
-
-    return parameters
-
-
-def _safe_likelihood_call(likelihood, parameters=None, use_ratio=False):
-    if use_ratio:
-        method = likelihood.log_likelihood_ratio
-    else:
-        method = likelihood.log_likelihood
-
-    if "parameters" in inspect.signature(method).parameters:
-        logl = method(parameters=parameters)
-    else:
-        if PARAMETERS_AS_STATE == "FALSE":
-            raise LikelihoodParameterError(
-                f"Unable to call {likelihood} with {parameters} as an argument"
-            )
-        elif PARAMETERS_AS_STATE == "WARN":
-            warnings.warn(
-                f"Using parameters as state for {likelihood}. "
-                "This is deprecated behaviour  and will be removed in Bilby version 3. "
-                "See https://bilby-dev.github.io/bilby/parameters for more details.",
-                DeprecationWarning,
-            )
-        likelihood.parameters.update(parameters)
-        logl = method()
-    return logl
-
 
 class Likelihood:
 
-    def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
-        if (
-            "parameters" not in inspect.signature(cls.log_likelihood).parameters
-            or "parameters" not in inspect.signature(cls.log_likelihood_ratio).parameters
-        ):
-            warnings.warn(
-                f"{cls} log_likelihood or log_likelihood_ratio method does not "
-                "accept 'parameters' as an argument. "
-                "This is deprecated behaviour  and will be removed in Bilby version 3. "
-                "See https://bilby-dev.github.io/bilby/parameters for more details.",
-                FutureWarning,
-            )
-
-    def __init__(self, parameters=None):
+    def __init__(self):
         """Empty likelihood class to be subclassed by other likelihoods
 
         Parameters
@@ -96,43 +20,13 @@ class Likelihood:
         parameters: dict
             A dictionary of the parameter names and associated values
         """
-        self.parameters = parameters
         self._meta_data = None
         self._marginalized_parameters = []
-
-    @property
-    def parameters(self):
-        msg = (
-            f"Parameter attribute queried for {self.__class__}. "
-            "This is deprecated behaviour  and will be removed in Bilby version 3. "
-            "See https://bilby-dev.github.io/bilby/parameters for more details."
-        )
-        if PARAMETERS_AS_STATE == "FALSE":
-            raise LikelihoodParameterError(msg)
-        elif PARAMETERS_AS_STATE == "WARN":
-            warnings.warn(msg, FutureWarning)
-        return self._parameters
-
-    @parameters.setter
-    def parameters(self, parameters):
-        if parameters is not None:
-            msg = (
-                f"Setting non-trivial parameters for {self.__class__}. "
-                "This is deprecated behaviour  and will be removed in Bilby version 3. "
-                "See https://bilby-dev.github.io/bilby/parameters for more details."
-            )
-            if PARAMETERS_AS_STATE == "FALSE":
-                raise LikelihoodParameterError(msg)
-            elif PARAMETERS_AS_STATE == "WARN":
-                warnings.warn(msg, FutureWarning)
-        else:
-            parameters = dict()
-        self._parameters = parameters
 
     def __repr__(self):
         return self.__class__.__name__
 
-    def log_likelihood(self, parameters=None):
+    def log_likelihood(self, parameters):
         """
 
         Returns
@@ -150,20 +44,14 @@ class Likelihood:
         """
         return np.nan
 
-    def log_likelihood_ratio(self, parameters=None):
+    def log_likelihood_ratio(self, parameters):
         """Difference between log likelihood and noise log likelihood
 
         Returns
         =======
         float
         """
-        try:
-            return self.log_likelihood(parameters=parameters) - self.noise_log_likelihood()
-        except TypeError:
-            if PARAMETERS_AS_STATE != "FALSE":
-                return self.log_likelihood() - self.noise_log_likelihood()
-            else:
-                raise
+        return self.log_likelihood(parameters=parameters) - self.noise_log_likelihood()
 
     @property
     def meta_data(self):
@@ -193,10 +81,9 @@ class ZeroLikelihood(Likelihood):
 
     def __init__(self, likelihood):
         super(ZeroLikelihood, self).__init__()
-        self.parameters = likelihood.parameters
         self._parent = likelihood
 
-    def log_likelihood(self, parameters=None):
+    def log_likelihood(self, parameters):
         return 0
 
     def noise_log_likelihood(self):
@@ -239,9 +126,8 @@ class Analytical1DLikelihood(Likelihood):
         """ Make func read-only """
         return self._func
 
-    def model_parameters(self, parameters=None):
+    def model_parameters(self, parameters):
         """ This sets up the function only parameters (i.e. not sigma for the GaussianLikelihood) """
-        parameters = _fallback_to_parameters(self, parameters)
         return {key: parameters[key] for key in self.function_keys}
 
     @property
@@ -276,7 +162,7 @@ class Analytical1DLikelihood(Likelihood):
             y = np.array([y])
         self._y = y
 
-    def residual(self, parameters=None):
+    def residual(self, parameters):
         """ Residual of the function against the data. """
         return self.y - self.func(self.x, **self.model_parameters(parameters=parameters), **self.kwargs)
 
@@ -307,8 +193,7 @@ class GaussianLikelihood(Analytical1DLikelihood):
         super(GaussianLikelihood, self).__init__(x=x, y=y, func=func, **kwargs)
         self.sigma = sigma
 
-    def log_likelihood(self, parameters=None):
-        parameters = _fallback_to_parameters(self, parameters)
+    def log_likelihood(self, parameters):
         sigma = parameters.get("sigma", self.sigma)
         log_l = np.sum(- (self.residual(parameters) / sigma)**2 / 2 -
                        np.log(2 * np.pi * sigma**2) / 2)
@@ -326,10 +211,7 @@ class GaussianLikelihood(Analytical1DLikelihood):
         that if sigma is not in parameters the attribute is used which was
         given at init (i.e. the known sigma as either a float or array).
         """
-        if PARAMETERS_AS_STATE == "FALSE":
-            return self._sigma
-        else:
-            return self.parameters.get('sigma', self._sigma)
+        return self._sigma
 
     @sigma.setter
     def sigma(self, sigma):
@@ -368,7 +250,7 @@ class PoissonLikelihood(Analytical1DLikelihood):
 
         super(PoissonLikelihood, self).__init__(x=x, y=y, func=func, **kwargs)
 
-    def log_likelihood(self, parameters=None):
+    def log_likelihood(self, parameters):
         rate = self.func(self.x, **self.model_parameters(parameters=parameters), **self.kwargs)
         if not isinstance(rate, np.ndarray):
             raise ValueError(
@@ -419,7 +301,7 @@ class ExponentialLikelihood(Analytical1DLikelihood):
         """
         super(ExponentialLikelihood, self).__init__(x=x, y=y, func=func, **kwargs)
 
-    def log_likelihood(self, parameters=None):
+    def log_likelihood(self, parameters):
         mu = self.func(self.x, **self.model_parameters(parameters=parameters), **self.kwargs)
         if np.any(mu < 0.):
             return -np.inf
@@ -477,8 +359,7 @@ class StudentTLikelihood(Analytical1DLikelihood):
         self.nu = nu
         self.sigma = sigma
 
-    def log_likelihood(self, parameters=None):
-        parameters = _fallback_to_parameters(self, parameters)
+    def log_likelihood(self, parameters):
         nu = parameters.get("nu", self.nu)
         if nu <= 0.:
             raise ValueError("Number of degrees of freedom for Student's "
@@ -506,10 +387,7 @@ class StudentTLikelihood(Analytical1DLikelihood):
         values will be used. Otherwise, the attribute nu is used. The logic is
         that if nu is not in parameters the attribute is used which was
         given at init (i.e. the known nu as a float)."""
-        if PARAMETERS_AS_STATE == "FALSE":
-            return self._nu
-        else:
-            return self.parameters.get('nu', self._nu)
+        return self._nu
 
     @nu.setter
     def nu(self, nu):
@@ -540,11 +418,10 @@ class Multinomial(Likelihood):
         self.base = base
         self._nll = None
 
-    def log_likelihood(self, parameters=None):
+    def log_likelihood(self, parameters):
         """
         Since n - 1 parameters are sampled, the last parameter is 1 - the rest
         """
-        parameters = _fallback_to_parameters(self, parameters)
         probs = [parameters[self.base + str(ii)]
                  for ii in range(self.n - 1)]
         probs.append(1 - sum(probs))
@@ -590,8 +467,7 @@ class AnalyticalMultidimensionalCovariantGaussian(Likelihood):
     def dim(self):
         return len(self.cov[0])
 
-    def log_likelihood(self, parameters=None):
-        parameters = _fallback_to_parameters(self, parameters)
+    def log_likelihood(self, parameters):
         x = np.array([parameters["x{0}".format(i)] for i in range(self.dim)])
         return self.pdf.logpdf(x)
 
@@ -623,8 +499,7 @@ class AnalyticalMultidimensionalBimodalCovariantGaussian(Likelihood):
     def dim(self):
         return len(self.cov[0])
 
-    def log_likelihood(self, parameters=None):
-        parameters = _fallback_to_parameters(self, parameters)
+    def log_likelihood(self, parameters):
         x = np.array([parameters["x{0}".format(i)] for i in range(self.dim)])
         return -np.log(2) + np.logaddexp(self.pdf_1.logpdf(x), self.pdf_2.logpdf(x))
 
@@ -646,21 +521,7 @@ class JointLikelihood(Likelihood):
             likelihoods to be combined parsed as arguments
         """
         self.likelihoods = likelihoods
-        if PARAMETERS_AS_STATE == "FALSE":
-            params = None
-        else:
-            params = dict()
-        super(JointLikelihood, self).__init__(parameters=params)
-        self.__sync_parameters()
-
-    def __sync_parameters(self):
-        """ Synchronizes parameters between the likelihoods
-        so that all likelihoods share a single parameter dict."""
-        if PARAMETERS_AS_STATE != "FALSE":
-            for likelihood in self.likelihoods:
-                self.parameters.update(likelihood.parameters)
-            for likelihood in self.likelihoods:
-                likelihood.parameters = self.parameters
+        super(JointLikelihood, self).__init__()
 
     @property
     def likelihoods(self):
@@ -681,7 +542,7 @@ class JointLikelihood(Likelihood):
         else:
             raise ValueError('Input likelihood is not a list of tuple. You need to set multiple likelihoods.')
 
-    def log_likelihood(self, parameters=None):
+    def log_likelihood(self, parameters):
         """ This is just the sum of the log likelihoods of all parts of the joint likelihood"""
         return sum([likelihood.log_likelihood(parameters=parameters) for likelihood in self.likelihoods])
 
@@ -747,11 +608,7 @@ class _GPLikelihood(Likelihood):
         self.GPClass = gp_class
         self.gp = self.GPClass(kernel=self.kernel, mean=self.mean_model, fit_mean=True, fit_white_noise=True)
         self.gp.compute(self.t, yerr=self.yerr)
-        if PARAMETERS_AS_STATE == "FALSE":
-            parameters = None
-        else:
-            parameters = self.gp.get_parameter_dict()
-        super().__init__(parameters=parameters)
+        super().__init__()
 
     def set_parameters(self, parameters):
         """
@@ -768,8 +625,6 @@ class _GPLikelihood(Likelihood):
                 self.gp.set_parameter(name=name, value=value)
             except ValueError:
                 pass
-            if PARAMETERS_AS_STATE != "FALSE":
-                self.parameters[name] = value
 
 
 class CeleriteLikelihood(_GPLikelihood):
@@ -797,7 +652,7 @@ class CeleriteLikelihood(_GPLikelihood):
         import celerite
         super().__init__(kernel=kernel, mean_model=mean_model, t=t, y=y, yerr=yerr, gp_class=celerite.GP)
 
-    def log_likelihood(self, parameters=None):
+    def log_likelihood(self, parameters):
         """
         Calculate the log-likelihood for the Gaussian process given the current parameters.
 
@@ -805,7 +660,6 @@ class CeleriteLikelihood(_GPLikelihood):
         =======
         float: The log-likelihood value.
         """
-        parameters = _fallback_to_parameters(self, parameters)
         self.gp.set_parameter_vector(vector=np.array(list(parameters.values())))
         try:
             return self.gp.log_likelihood(self.y)
@@ -838,7 +692,7 @@ class GeorgeLikelihood(_GPLikelihood):
         import george
         super().__init__(kernel=kernel, mean_model=mean_model, t=t, y=y, yerr=yerr, gp_class=george.GP)
 
-    def log_likelihood(self, parameters=None):
+    def log_likelihood(self, parameters):
         """
         Calculate the log-likelihood for the Gaussian process given the current parameters.
 
@@ -846,7 +700,6 @@ class GeorgeLikelihood(_GPLikelihood):
         =======
         float: The log-likelihood value.
         """
-        parameters = _fallback_to_parameters(self, parameters)
         for name, value in parameters.items():
             try:
                 self.gp.set_parameter(name=name, value=value)

--- a/bilby/core/likelihood.py
+++ b/bilby/core/likelihood.py
@@ -1,13 +1,10 @@
 import copy
-import inspect
-import os
-import warnings
 
 import numpy as np
 from scipy.special import gammaln, xlogy
 from scipy.stats import multivariate_normal
 
-from .utils import infer_parameters_from_function, infer_args_from_function_except_n_args, logger
+from .utils import infer_parameters_from_function, infer_args_from_function_except_n_args
 
 
 class Likelihood:

--- a/bilby/core/likelihood.py
+++ b/bilby/core/likelihood.py
@@ -10,13 +10,7 @@ from .utils import infer_parameters_from_function, infer_args_from_function_exce
 class Likelihood:
 
     def __init__(self):
-        """Empty likelihood class to be subclassed by other likelihoods
-
-        Parameters
-        ==========
-        parameters: dict
-            A dictionary of the parameter names and associated values
-        """
+        """Empty likelihood class to be subclassed by other likelihoods"""
         self._meta_data = None
         self._marginalized_parameters = []
 
@@ -25,6 +19,11 @@ class Likelihood:
 
     def log_likelihood(self, parameters):
         """
+
+        Parameters
+        ==========
+        parameters: dict
+            A dictionary of the parameter names and associated values
 
         Returns
         =======
@@ -43,6 +42,11 @@ class Likelihood:
 
     def log_likelihood_ratio(self, parameters):
         """Difference between log likelihood and noise log likelihood
+
+        Parameters
+        ==========
+        parameters: dict
+            A dictionary of the parameter names and associated values
 
         Returns
         =======
@@ -418,6 +422,15 @@ class Multinomial(Likelihood):
     def log_likelihood(self, parameters):
         """
         Since n - 1 parameters are sampled, the last parameter is 1 - the rest
+
+        Parameters
+        ==========
+        parameters: dict
+            A dictionary of the parameter names and associated values
+
+        Returns
+        =======
+        float
         """
         probs = [parameters[self.base + str(ii)]
                  for ii in range(self.n - 1)]
@@ -442,16 +455,16 @@ class Multinomial(Likelihood):
 
 class AnalyticalMultidimensionalCovariantGaussian(Likelihood):
     """
-        A multivariate Gaussian likelihood
-        with known analytic solution.
+    A multivariate Gaussian likelihood
+    with known analytic solution.
 
-        Parameters
-        ==========
-        mean: array_like
-            Array with the mean values of distribution
-        cov: array_like
-            The ndim*ndim covariance matrix
-        """
+    Parameters
+    ==========
+    mean: array_like
+        Array with the mean values of distribution
+    cov: array_like
+        The ndim*ndim covariance matrix
+    """
 
     def __init__(self, mean, cov):
         self.cov = np.atleast_2d(cov)
@@ -471,17 +484,17 @@ class AnalyticalMultidimensionalCovariantGaussian(Likelihood):
 
 class AnalyticalMultidimensionalBimodalCovariantGaussian(Likelihood):
     """
-        A multivariate Gaussian likelihood
-        with known analytic solution.
+    A multivariate Gaussian likelihood
+    with known analytic solution.
 
-        Parameters
-        ==========
-        mean_1: array_like
-            Array with the mean value of the first mode
-        mean_2: array_like
-            Array with the mean value of the second mode
-        cov: array_like
-        """
+    Parameters
+    ==========
+    mean_1: array_like
+        Array with the mean value of the first mode
+    mean_2: array_like
+        Array with the mean value of the second mode
+    cov: array_like
+    """
 
     def __init__(self, mean_1, mean_2, cov):
         self.cov = np.atleast_2d(cov)
@@ -540,7 +553,18 @@ class JointLikelihood(Likelihood):
             raise ValueError('Input likelihood is not a list of tuple. You need to set multiple likelihoods.')
 
     def log_likelihood(self, parameters):
-        """ This is just the sum of the log likelihoods of all parts of the joint likelihood"""
+        """
+        This is just the sum of the log likelihoods of all parts of the joint likelihood
+
+        Parameters
+        ==========
+        parameters: dict
+            A dictionary of the parameter names and associated values
+
+        Returns
+        =======
+        float
+        """
         return sum([likelihood.log_likelihood(parameters=parameters) for likelihood in self.likelihoods])
 
     def noise_log_likelihood(self):
@@ -576,26 +600,26 @@ class _GPLikelihood(Likelihood):
 
     def __init__(self, kernel, mean_model, t, y, yerr=1e-6, gp_class=None):
         """
-            Basic Gaussian Process likelihood interface for `celerite` and `george`.
-            For `celerite` documentation see: https://celerite.readthedocs.io/en/stable/
-            For `george` documentation see: https://george.readthedocs.io/en/latest/
+        Basic Gaussian Process likelihood interface for `celerite` and `george`.
+        For `celerite` documentation see: https://celerite.readthedocs.io/en/stable/
+        For `george` documentation see: https://george.readthedocs.io/en/latest/
 
-            Parameters
-            ==========
-            kernel: Union[celerite.term.Term, george.kernels.Kernel]
-                `celerite` or `george` kernel. See the respective package documentation about the usage.
-            mean_model: Union[celerite.modeling.Model, george.modeling.Model]
-                Mean model
-            t: array_like
-                The `times` or `x` values of the data set.
-            y: array_like
-                The `y` values of the data set.
-            yerr: float, int, array_like, optional
-                The error values on the y-values. If a single value is given, it is assumed that the value
-                applies for all y-values. Default is 1e-6, effectively assuming that no y-errors are present.
-            gp_class: type, None, optional
-                GPClass to use. This is determined by the child class used to instantiate the GP. Should usually
-                not be given by the user and is mostly used for testing
+        Parameters
+        ==========
+        kernel: Union[celerite.term.Term, george.kernels.Kernel]
+            `celerite` or `george` kernel. See the respective package documentation about the usage.
+        mean_model: Union[celerite.modeling.Model, george.modeling.Model]
+            Mean model
+        t: array_like
+            The `times` or `x` values of the data set.
+        y: array_like
+            The `y` values of the data set.
+        yerr: float, int, array_like, optional
+            The error values on the y-values. If a single value is given, it is assumed that the value
+            applies for all y-values. Default is 1e-6, effectively assuming that no y-errors are present.
+        gp_class: type, None, optional
+            GPClass to use. This is determined by the child class used to instantiate the GP. Should usually
+            not be given by the user and is mostly used for testing
         """
         self.kernel = kernel
         self.mean_model = mean_model
@@ -628,23 +652,23 @@ class CeleriteLikelihood(_GPLikelihood):
 
     def __init__(self, kernel, mean_model, t, y, yerr=1e-6):
         """
-            Basic Gaussian Process likelihood interface for `celerite` and `george`.
-            For `celerite` documentation see: https://celerite.readthedocs.io/en/stable/
-            For `george` documentation see: https://george.readthedocs.io/en/latest/
+        Basic Gaussian Process likelihood interface for `celerite` and `george`.
+        For `celerite` documentation see: https://celerite.readthedocs.io/en/stable/
+        For `george` documentation see: https://george.readthedocs.io/en/latest/
 
-            Parameters
-            ==========
-            kernel: celerite.term.Term
-                `celerite` or `george` kernel. See the respective package documentation about the usage.
-            mean_model: celerite.modeling.Model
-                Mean model
-            t: array_like
-                The `times` or `x` values of the data set.
-            y: array_like
-                The `y` values of the data set.
-            yerr: float, int, array_like, optional
-                The error values on the y-values. If a single value is given, it is assumed that the value
-                applies for all y-values. Default is 1e-6, effectively assuming that no y-errors are present.
+        Parameters
+        ==========
+        kernel: celerite.term.Term
+            `celerite` or `george` kernel. See the respective package documentation about the usage.
+        mean_model: celerite.modeling.Model
+            Mean model
+        t: array_like
+            The `times` or `x` values of the data set.
+        y: array_like
+            The `y` values of the data set.
+        yerr: float, int, array_like, optional
+            The error values on the y-values. If a single value is given, it is assumed that the value
+            applies for all y-values. Default is 1e-6, effectively assuming that no y-errors are present.
         """
         import celerite
         super().__init__(kernel=kernel, mean_model=mean_model, t=t, y=y, yerr=yerr, gp_class=celerite.GP)
@@ -668,23 +692,23 @@ class GeorgeLikelihood(_GPLikelihood):
 
     def __init__(self, kernel, mean_model, t, y, yerr=1e-6):
         """
-            Basic Gaussian Process likelihood interface for `celerite` and `george`.
-            For `celerite` documentation see: https://celerite.readthedocs.io/en/stable/
-            For `george` documentation see: https://george.readthedocs.io/en/latest/
+        Basic Gaussian Process likelihood interface for `celerite` and `george`.
+        For `celerite` documentation see: https://celerite.readthedocs.io/en/stable/
+        For `george` documentation see: https://george.readthedocs.io/en/latest/
 
-            Parameters
-            ==========
-            kernel: george.kernels.Kernel
-                `celerite` or `george` kernel. See the respective package documentation about the usage.
-            mean_model: george.modeling.Model
-                Mean model
-            t: array_like
-                The `times` or `x` values of the data set.
-            y: array_like
-                The `y` values of the data set.
-            yerr: float, int, array_like, optional
-                The error values on the y-values. If a single value is given, it is assumed that the value
-                applies for all y-values. Default is 1e-6, effectively assuming that no y-errors are present.
+        Parameters
+        ==========
+        kernel: george.kernels.Kernel
+            `celerite` or `george` kernel. See the respective package documentation about the usage.
+        mean_model: george.modeling.Model
+            Mean model
+        t: array_like
+            The `times` or `x` values of the data set.
+        y: array_like
+            The `y` values of the data set.
+        yerr: float, int, array_like, optional
+            The error values on the y-values. If a single value is given, it is assumed that the value
+            applies for all y-values. Default is 1e-6, effectively assuming that no y-errors are present.
         """
         import george
         super().__init__(kernel=kernel, mean_model=mean_model, t=t, y=y, yerr=yerr, gp_class=george.GP)

--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -15,7 +15,6 @@ import pandas as pd
 import scipy.stats
 
 from . import utils
-from .likelihood import _safe_likelihood_call
 from .utils import (
     logger, infer_parameters_from_function,
     check_directory_exists_and_if_not_mkdir,
@@ -246,8 +245,11 @@ def get_weights_for_reweighting(
         with multiprocessing.Pool(processes=npool) as pool:
             chunksize = max(100, n // (2 * npool))
             return list(tqdm(
-                pool.imap(partial(_safe_likelihood_call, this_logl),
-                        dict_samples[starting_index:], chunksize=chunksize),
+                pool.imap(
+                    this_logl.log_likelihood,
+                    dict_samples[starting_index:],
+                    chunksize=chunksize,
+                ),
                 desc='Computing likelihoods',
                 total=n)
             )

--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -9,7 +9,6 @@ from copy import copy
 from importlib import import_module
 from itertools import product
 import multiprocessing
-from functools import partial
 import numpy as np
 import pandas as pd
 import scipy.stats

--- a/bilby/core/sampler/fake_sampler.py
+++ b/bilby/core/sampler/fake_sampler.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from ..likelihood import _safe_likelihood_call
 from ..result import read_in_result
 from .base_sampler import Sampler
 
@@ -77,7 +76,7 @@ class FakeSampler(Sampler):
             sample = posterior.iloc[i]
 
             params = sample.to_dict()
-            logl = _safe_likelihood_call(self.likelihood, params, use_ratio=True)
+            logl = self.likelihood.log_likelihood_ratio(params)
             sample.log_likelihood = logl
             likelihood_ratios.append(logl)
 

--- a/bilby/gw/likelihood/basic.py
+++ b/bilby/gw/likelihood/basic.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from ...core.likelihood import Likelihood, _fallback_to_parameters
+from ...core.likelihood import Likelihood
 
 
 class BasicGravitationalWaveTransient(Likelihood):
@@ -48,7 +48,7 @@ class BasicGravitationalWaveTransient(Likelihood):
                 interferometer.power_spectral_density_array)
         return log_l.real
 
-    def log_likelihood(self, parameters=None):
+    def log_likelihood(self, parameters):
         """ Calculates the real part of log-likelihood value
 
         Returns
@@ -56,7 +56,6 @@ class BasicGravitationalWaveTransient(Likelihood):
         float: The real part of the log likelihood
 
         """
-        parameters = _fallback_to_parameters(self, parameters)
         log_l = 0
         waveform_polarizations = \
             self.waveform_generator.frequency_domain_strain(parameters)
@@ -68,7 +67,7 @@ class BasicGravitationalWaveTransient(Likelihood):
         return log_l.real
 
     def log_likelihood_interferometer(self, waveform_polarizations,
-                                      interferometer, parameters=None):
+                                      interferometer, parameters):
         """
 
         Parameters
@@ -83,7 +82,6 @@ class BasicGravitationalWaveTransient(Likelihood):
         float: The real part of the log-likelihood for this interferometer
 
         """
-        parameters = _fallback_to_parameters(self, parameters)
         signal_ifo = interferometer.get_detector_response(
             waveform_polarizations, parameters)
 

--- a/bilby/gw/likelihood/multiband.py
+++ b/bilby/gw/likelihood/multiband.py
@@ -11,7 +11,6 @@ from ...core.utils import (
     recursively_load_dict_contents_from_group,
     recursively_save_dict_contents_to_group
 )
-from ...core.likelihood import _fallback_to_parameters
 from ..prior import CBCPriorDict
 from ..utils import ln_i0
 
@@ -726,7 +725,7 @@ class MBGravitationalWaveTransient(GravitationalWaveTransient):
         ) / 2
         self.interferometers.reference_time = self._beam_pattern_reference_time
 
-    def calculate_snrs(self, waveform_polarizations, interferometer, return_array=True, parameters=None):
+    def calculate_snrs(self, waveform_polarizations, interferometer, *, return_array=True, parameters):
         """
         Compute the snrs
 
@@ -747,7 +746,6 @@ class MBGravitationalWaveTransient(GravitationalWaveTransient):
             An object containing the SNR quantities.
 
         """
-        parameters = _fallback_to_parameters(self, parameters)
 
         modes = {
             mode: value[self.unique_to_original_frequencies]
@@ -807,8 +805,7 @@ class MBGravitationalWaveTransient(GravitationalWaveTransient):
         for mode in signal:
             signal[mode] *= self._ref_dist / new_distance
 
-    def generate_time_sample_from_marginalized_likelihood(self, signal_polarizations=None, parameters=None):
-        parameters = _fallback_to_parameters(self, parameters)
+    def generate_time_sample_from_marginalized_likelihood(self, signal_polarizations=None, *, parameters):
         parameters.update(self.get_sky_frame_parameters(parameters=parameters))
         if signal_polarizations is None:
             signal_polarizations = \

--- a/bilby/gw/likelihood/relative.py
+++ b/bilby/gw/likelihood/relative.py
@@ -7,7 +7,6 @@ from .base import GravitationalWaveTransient
 from ...core.utils import logger
 from ...core.prior.base import Constraint
 from ...core.prior import DeltaFunction
-from ...core.likelihood import _fallback_to_parameters
 from ..utils import noise_weighted_inner_product
 
 
@@ -362,8 +361,7 @@ class RelativeBinningGravitationalWaveTransient(GravitationalWaveTransient):
 
         self.summary_data = summary_data
 
-    def compute_waveform_ratio_per_interferometer(self, waveform_polarizations, interferometer, parameters=None):
-        parameters = _fallback_to_parameters(self, parameters)
+    def compute_waveform_ratio_per_interferometer(self, waveform_polarizations, interferometer, parameters):
         name = interferometer.name
         strain = interferometer.get_detector_response(
             waveform_polarizations=waveform_polarizations,
@@ -378,7 +376,7 @@ class RelativeBinningGravitationalWaveTransient(GravitationalWaveTransient):
 
         return [r0, r1]
 
-    def _compute_full_waveform(self, signal_polarizations, interferometer, parameters=None):
+    def _compute_full_waveform(self, signal_polarizations, interferometer, parameters):
         fiducial_waveform = self.per_detector_fiducial_waveforms[interferometer.name]
         r0, r1 = self.compute_waveform_ratio_per_interferometer(
             waveform_polarizations=signal_polarizations,
@@ -396,7 +394,7 @@ class RelativeBinningGravitationalWaveTransient(GravitationalWaveTransient):
         full_waveform_ratio[idxs] = duplicated_r0 + duplicated_r1 * (f[idxs] - duplicated_fm)
         return fiducial_waveform * full_waveform_ratio
 
-    def calculate_snrs(self, waveform_polarizations, interferometer, return_array=True, parameters=None):
+    def calculate_snrs(self, waveform_polarizations, interferometer, *, return_array=True, parameters):
         r0, r1 = self.compute_waveform_ratio_per_interferometer(
             waveform_polarizations=waveform_polarizations,
             interferometer=interferometer,

--- a/bilby/gw/waveform_generator.py
+++ b/bilby/gw/waveform_generator.py
@@ -102,7 +102,7 @@ class WaveformGenerator(object):
             .format(self.duration, self.sampling_frequency, self.start_time, fdsm_name, tdsm_name,
                     param_conv_name, self.waveform_arguments)
 
-    def frequency_domain_strain(self, parameters):
+    def frequency_domain_strain(self, parameters=None):
         """ Wrapper to source_model.
 
         Converts parameters with self.parameter_conversion before handing it off to the source model.
@@ -110,8 +110,10 @@ class WaveformGenerator(object):
 
         Parameters
         ==========
-        parameters: dict
+        parameters: dict, optional
             Parameters to evaluate the waveform for.
+            If not passed and the generator has been called previously,
+            the last used parameters will be used.
 
         Returns
         =======
@@ -129,7 +131,7 @@ class WaveformGenerator(object):
                                       transformed_model=self.time_domain_source_model,
                                       transformed_model_data_points=self.time_array)
 
-    def time_domain_strain(self, parameters):
+    def time_domain_strain(self, parameters=None):
         """ Wrapper to source_model.
 
         Converts parameters with self.parameter_conversion before handing it off to the source model.
@@ -138,8 +140,10 @@ class WaveformGenerator(object):
 
         Parameters
         ==========
-        parameters: dict
+        parameters: dict, None
             Parameters to evaluate the waveform for.
+            If not passed and the generator has been called previously,
+            the last used parameters will be used.
 
         Returns
         =======

--- a/bilby/gw/waveform_generator.py
+++ b/bilby/gw/waveform_generator.py
@@ -44,8 +44,9 @@ class WaveformGenerator(object):
             A python function taking some arguments and returning the time
             domain strain. Note the first argument must be the times at
             which to compute the strain
-        parameters: dict, optional
-            Initial values for the parameters
+        parameters: DEPRECATED
+            Passing parameters via the waveform generator init is deprecated
+            and will be removed in a future release.
         parameter_conversion: func, optional
             Function to convert from sampled parameters to parameters of the
             waveform generator. Default value is the identity, i.e. it leaves
@@ -101,7 +102,7 @@ class WaveformGenerator(object):
             .format(self.duration, self.sampling_frequency, self.start_time, fdsm_name, tdsm_name,
                     param_conv_name, self.waveform_arguments)
 
-    def frequency_domain_strain(self, parameters=None):
+    def frequency_domain_strain(self, parameters):
         """ Wrapper to source_model.
 
         Converts parameters with self.parameter_conversion before handing it off to the source model.
@@ -109,7 +110,7 @@ class WaveformGenerator(object):
 
         Parameters
         ==========
-        parameters: dict, optional
+        parameters: dict
             Parameters to evaluate the waveform for.
 
         Returns
@@ -128,7 +129,7 @@ class WaveformGenerator(object):
                                       transformed_model=self.time_domain_source_model,
                                       transformed_model_data_points=self.time_array)
 
-    def time_domain_strain(self, parameters=None):
+    def time_domain_strain(self, parameters):
         """ Wrapper to source_model.
 
         Converts parameters with self.parameter_conversion before handing it off to the source model.
@@ -137,7 +138,7 @@ class WaveformGenerator(object):
 
         Parameters
         ==========
-        parameters: dict, optional
+        parameters: dict
             Parameters to evaluate the waveform for.
 
         Returns
@@ -211,28 +212,16 @@ class WaveformGenerator(object):
         =======
         dict: The dictionary of parameter key-value pairs
 
+        Raises
+        ======
+        AttributeError: If :code:`parameters` is not present in the internal cache.
         """
-        if hasattr(self, "_parameters"):
-            return self._parameters
+        if self._cache.get("parameters", None) is not None:
+            return self._cache["parameters"]
         else:
-            return self._cache.get("parameters", None)
-
-    @parameters.setter
-    def parameters(self, parameters):
-        """
-        Set parameters, this applies the conversion function and then removes
-        any parameters which aren't required by the source function.
-
-        (set.symmetric_difference is the opposite of set.intersection)
-
-        Parameters
-        ==========
-        parameters: dict
-            Input parameter dictionary, this is copied, passed to the conversion
-            function and has self.waveform_arguments added to it.
-        """
-        new_parameters = self._format_parameters(parameters)
-        self._parameters = new_parameters
+            raise AttributeError(
+                "Parameters not available in the WaveformGenerator cache."
+            )
 
     def _format_parameters(self, parameters):
         if not isinstance(parameters, dict):
@@ -316,8 +305,9 @@ class GWSignalWaveformGenerator(WaveformGenerator):
         Time duration of data
     start_time: float, optional
         Starting time of the time array
-    parameters: dict, optional
-        Initial values for the parameters
+    parameters: DEPRECATED
+        Passing parameters via the waveform generator init is deprecated
+        and will be removed in a future release.
     parameter_conversion: func, optional
         Function to convert from sampled parameters to parameters of the
         waveform generator. The default value is the identity, i.e., it leaves

--- a/bilby/hyper/likelihood.py
+++ b/bilby/hyper/likelihood.py
@@ -3,7 +3,7 @@ import logging
 
 import numpy as np
 
-from ..core.likelihood import Likelihood, _fallback_to_parameters
+from ..core.likelihood import Likelihood
 from .model import Model
 from ..core.prior import PriorDict
 
@@ -59,8 +59,7 @@ class HyperparameterLikelihood(Likelihood):
         self.samples_factor =\
             - self.n_posteriors * np.log(self.samples_per_posterior)
 
-    def log_likelihood_ratio(self, parameters=None):
-        parameters = _fallback_to_parameters(self, parameters)
+    def log_likelihood_ratio(self, parameters):
         log_l = np.sum(np.log(np.sum(self.hyper_prior.prob(self.data, **parameters) /
                        self.data['prior'], axis=-1)))
         log_l += self.samples_factor
@@ -69,7 +68,7 @@ class HyperparameterLikelihood(Likelihood):
     def noise_log_likelihood(self):
         return self.evidence_factor
 
-    def log_likelihood(self, parameters=None):
+    def log_likelihood(self, parameters):
         return self.noise_log_likelihood() + self.log_likelihood_ratio(parameters=parameters)
 
     def resample_posteriors(self, max_samples=None):

--- a/examples/core_examples/alternative_samplers/linear_regression_pymc_custom_likelihood.py
+++ b/examples/core_examples/alternative_samplers/linear_regression_pymc_custom_likelihood.py
@@ -82,7 +82,7 @@ class GaussianLikelihoodPyMC(bilby.core.likelihood.GaussianLikelihood):
         """
         super(GaussianLikelihoodPyMC, self).__init__(x=x, y=y, func=func, sigma=sigma)
 
-    def log_likelihood(self, sampler=None, parameters=None):
+    def log_likelihood(self, sampler=None, *, parameters):
         """
         Parameters
         ----------

--- a/test/gw/waveform_generator_test.py
+++ b/test/gw/waveform_generator_test.py
@@ -135,9 +135,11 @@ class TestWaveformGeneratorInstantiationWithoutOptionalParameters(unittest.TestC
         self.assertIsInstance(self.waveform_generator.time_array, np.ndarray)
 
     def test_source_model_parameters(self):
-        self.waveform_generator.parameters = self.simulation_parameters.copy()
+        formatted_parameters = self.waveform_generator._format_parameters(
+            self.simulation_parameters.copy()
+        )
         self.assertListEqual(
-            sorted(list(self.waveform_generator.parameters.keys())),
+            sorted(list(formatted_parameters.keys())),
             sorted(list(self.simulation_parameters.keys())),
         )
 
@@ -229,32 +231,13 @@ class TestSetters(unittest.TestCase):
         self.waveform_generator = bilby.gw.waveform_generator.WaveformGenerator(
             1, 4096, frequency_domain_source_model=dummy_func_dict_return_value
         )
-        self.simulation_parameters = dict(
-            amplitude=1e-21,
-            mu=100,
-            sigma=1,
-            ra=1.375,
-            dec=-1.2108,
-            geocent_time=1126259642.413,
-            psi=2.659,
-        )
 
     def tearDown(self):
         del self.waveform_generator
-        del self.simulation_parameters
 
-    def test_parameter_setter_sets_expected_values_with_expected_keys(self):
-        self.waveform_generator.parameters = self.simulation_parameters.copy()
-        for key in self.simulation_parameters:
-            self.assertEqual(
-                self.waveform_generator.parameters[key], self.simulation_parameters[key]
-            )
-
-    def test_parameter_setter_none_handling(self):
-        with self.assertRaises(TypeError):
+    def test_parameter_setter_raises_error(self):
+        with self.assertRaises(AttributeError):
             self.waveform_generator.parameters = None
-        # self.assertListEqual(sorted(list(self.waveform_generator.parameters.keys())),
-        #                      sorted(list(self.simulation_parameters.keys())))
 
     def test_frequency_array_setter(self):
         new_frequency_array = np.arange(1, 100)
@@ -268,24 +251,6 @@ class TestSetters(unittest.TestCase):
         self.waveform_generator.time_array = new_time_array
         self.assertTrue(
             np.array_equal(new_time_array, self.waveform_generator.time_array)
-        )
-
-    def test_parameters_set_from_frequency_domain_source_model(self):
-        self.waveform_generator.frequency_domain_source_model = (
-            dummy_func_dict_return_value
-        )
-        self.waveform_generator.parameters = self.simulation_parameters.copy()
-        self.assertListEqual(
-            sorted(list(self.waveform_generator.parameters.keys())),
-            sorted(list(self.simulation_parameters.keys())),
-        )
-
-    def test_parameters_set_from_time_domain_source_model(self):
-        self.waveform_generator.time_domain_source_model = dummy_func_dict_return_value
-        self.waveform_generator.parameters = self.simulation_parameters.copy()
-        self.assertListEqual(
-            sorted(list(self.waveform_generator.parameters.keys())),
-            sorted(list(self.simulation_parameters.keys())),
         )
 
     def test_set_parameter_conversion_at_init(self):


### PR DESCRIPTION
Likelihoods (and the waveform generator) will no longer allow a `.parameters` attribute to be used.