### PR TITLE
Fixing #1047

### DIFF
--- a/bilby/core/prior/dict.py
+++ b/bilby/core/prior/dict.py
@@ -461,7 +461,7 @@ class PriorDict(dict):
                 sample = self.sample_subset(keys=keys, size=size)
                 is_valid = self.evaluate_constraints(sample)
                 n_tested_samples += 1
-                n_valid_samples += int(is_valid)
+                n_valid_samples += int(np.squeeze(is_valid))
                 check_efficiency(n_tested_samples, n_valid_samples)
                 if is_valid:
                     return sample


### PR DESCRIPTION
## Issue

[GitHub #1047](https://github.com/lscsoft/bilby/issues/1047)

`sample_subset_constrained` raised a `TypeError` when sampling with `size=None` or `size=1`:

```
TypeError: only 0-dimensional arrays can be converted to Python scalars
```

## Root Cause

`evaluate_constraints` returns a numpy array via `np.ones_like`. When sampling a single point, this is a 1-element array rather than a scalar. The subsequent `int(is_valid)` call on line 464 fails because `int()` only accepts 0-dimensional arrays.

## Fix

Wrap `is_valid` with `np.squeeze` before converting to `int`, reducing the 1-element array to a 0-d scalar:

```python
# before
n_valid_samples += int(is_valid)

# after
n_valid_samples += int(np.squeeze(is_valid))
```