### PR TITLE
docs: fix matched filter SNR docstrings (closes #731)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The original MRs are only visible on the [LIGO GitLab repository](https://git.li
 
 ## [Unreleased]
 
+### Fixes
+* Corrected incorrect docstrings for `matched_filter_snr` and `optimal_snr_squared` in `bilby/gw/utils.py` (closes #731)
+
 ## [2.7.1]
 
 ### Fixes

--- a/bilby/gw/utils.py
+++ b/bilby/gw/utils.py
@@ -155,7 +155,7 @@ def matched_filter_snr(signal, frequency_domain_strain, power_spectral_density, 
 
     Returns
     =======
-    float: The matched filter signal to noise ratio squared
+    complex: The complex matched filter signal to noise ratio
 
     """
     rho_mf = noise_weighted_inner_product(
@@ -184,7 +184,7 @@ def optimal_snr_squared(signal, power_spectral_density, duration):
 
     Returns
     =======
-    float: The matched filter signal to noise ratio squared
+    float: The square of the optimal matched filter signal to noise ratio
 
     """
     return noise_weighted_inner_product(signal, signal, power_spectral_density, duration)


### PR DESCRIPTION
## Summary

Fixes #731 — the docstrings for `matched_filter_snr` and `optimal_snr_squared` in `bilby/gw/utils.py` were inaccurate.

## Changes

### `matched_filter_snr()` (line 158)

The docstring stated the function returned the matched filter SNR squared, but it actually returns the **complex matched filter SNR** (not squared). The function computes:

```
rho_mf = <signal | strain> / sqrt(<signal | signal>)
       = <s|h> / sqrt(optimal_snr_squared)
```

This is the standard complex matched filter SNR. Dividing by `sqrt(<s|s>)` (the optimal SNR) gives the matched filter SNR directly, not its square.

**Before:**
```
float: The matched filter signal to noise ratio squared
```

**After:**
```
complex: The complex matched filter signal to noise ratio
```

### `optimal_snr_squared()` (line 187)

Following @ColmTalbot's suggestion in the issue discussion, updated the docstring to be more precise — calling it "the square of the optimal matched filter SNR" rather than just "matched filter SNR squared".

**Before:**
```
float: The matched filter signal to noise ratio squared
```

**After:**
```
float: The square of the optimal matched filter signal to noise ratio
```

## Test plan

- [x] No code behavior changed — only docstrings
- [x] CHANGELOG.md updated under `[Unreleased]`
- [x] Verified function behavior matches corrected documentation

## References

- Maggiore, "Gravitational Waves Vol 1", Chapter 7
- Finn 1992 (PRD 46, 5236) — matched filtering for gravitational wave detection