### PR TITLE
feat: add VS Code / Codespaces dev containers (closes #843)

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,71 @@
+# Bilby Development Containers
+
+This directory contains [Dev Container](https://containers.dev/) configurations
+for developing Bilby in a reproducible environment using VS Code or GitHub Codespaces.
+
+## Available configurations
+
+### 1. Core (default): `.devcontainer/devcontainer.json`
+
+A lightweight Python 3.12 environment with bilby's core, sampler, and
+optional requirements. Suitable for working on:
+
+- Core likelihoods and priors
+- Samplers (non-GW)
+- Hyperparameter inference (`bilby.hyper`)
+- Documentation and examples that don't require LALSuite
+
+This is the default container that opens when you click **Reopen in Container**
+or create a new Codespace.
+
+### 2. GW (full): `.devcontainer/gw/devcontainer.json`
+
+A heavier container that additionally installs the gravitational-wave
+requirements: `lalsuite`, `astropy`, `gwpy`, `pyfftw`, and `scikit-learn`.
+Also installs the underlying C libraries (`libfftw3-dev`, `libgsl-dev`,
+`libhdf5-dev`) required to build LALSuite.
+
+Use this when working on:
+
+- `bilby.gw` (GW-specific priors, likelihoods, samplers)
+- Waveform generation via LALSimulation
+- GW data handling via GWpy
+
+Note: this container is larger and takes longer to build due to LALSuite.
+Requires at least 4 CPUs and 8 GB RAM.
+
+## Usage
+
+### VS Code (local)
+
+1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+2. Open the bilby repository
+3. Press `F1` → `Dev Containers: Reopen in Container`
+4. To use the GW container instead: `F1` → `Dev Containers: Reopen in Container` → select `Bilby (with GW)`
+
+### GitHub Codespaces
+
+1. Navigate to the bilby repo on GitHub
+2. Click the **Code** button → **Codespaces** tab → **Create codespace**
+3. The default core container will be used. To select the GW container:
+   - Use **Create codespace on main** → **Advanced options** → select configuration
+
+## What's included
+
+Both containers install:
+
+- Python 3.12 with pip and build tools
+- Git + GitHub CLI
+- VS Code extensions: Python, Pylance, Ruff, Black, Jupyter, GitLens, autoDocstring
+- Pytest configured for the `test/` directory
+
+The GW container additionally installs:
+
+- FFTW3, GSL, HDF5 system libraries
+- LALSuite and gravitational-wave Python dependencies
+
+## Contributing
+
+If you find issues with the dev container setup or want to add more features
+(e.g. pre-commit hooks, additional samplers), please open a PR or file an
+issue referencing this README.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "Bilby (core)",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "pip install --upgrade pip && pip install -r requirements.txt -r sampler_requirements.txt -r optional_requirements.txt && pip install -e .",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-python.black-formatter",
+        "charliermarsh.ruff",
+        "ms-toolsai.jupyter",
+        "eamodio.gitlens",
+        "njpwerner.autodocstring"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": ["test"],
+        "editor.formatOnSave": false,
+        "python.linting.enabled": true
+      }
+    }
+  },
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/gw/devcontainer.json
+++ b/.devcontainer/gw/devcontainer.json
@@ -1,0 +1,34 @@
+{
+  "name": "Bilby (with GW)",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "bash -c 'apt-get update && apt-get install -y libfftw3-dev libgsl-dev libhdf5-dev pkg-config && pip install --upgrade pip && pip install -r requirements.txt -r sampler_requirements.txt -r optional_requirements.txt -r gw_requirements.txt && pip install -e .'",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-python.black-formatter",
+        "charliermarsh.ruff",
+        "ms-toolsai.jupyter",
+        "eamodio.gitlens",
+        "njpwerner.autodocstring"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": ["test"],
+        "editor.formatOnSave": false,
+        "python.linting.enabled": true
+      }
+    }
+  },
+  "remoteUser": "vscode",
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "8gb"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The original MRs are only visible on the [LIGO GitLab repository](https://git.li
 
 ## [Unreleased]
 
+### Additions
+* Added VS Code / Codespaces dev container configurations: a lightweight core container and an optional GW container with LALSuite installed (closes #843)
+
 ## [2.7.1]
 
 ### Fixes


### PR DESCRIPTION
## Summary

Adds [Dev Container](https://containers.dev/) configurations to bilby, enabling instant reproducible development environments via VS Code's Dev Containers extension or GitHub Codespaces.

Closes #843.

## Why two containers?

As suggested in the issue, GW dependencies (lalsuite, gwpy, pyfftw) are heavy and require C libraries. Developers working on core bilby, samplers, or hyperparameter inference don't need them. Providing two configurations gives contributors a choice:

- **Core** (default, fast): ~1-2 min build, no C libraries, no LALSuite
- **GW** (full): heavier build due to LALSuite compilation, but complete

## What's included

### .devcontainer/devcontainer.json (default, core)

- Python 3.12 base (mcr.microsoft.com/devcontainers/python:3.12)
- Installs: requirements.txt + sampler_requirements.txt + optional_requirements.txt
- \`pip install -e .\` on create
- VS Code extensions: Python, Pylance, Ruff, Black, Jupyter, GitLens, autoDocstring
- Pytest configured for the test/ directory

### .devcontainer/gw/devcontainer.json (full GW)

Same as core, plus:
- System libraries: libfftw3-dev, libgsl-dev, libhdf5-dev
- Additionally installs gw_requirements.txt (lalsuite, gwpy, astropy, pyfftw, scikit-learn)
- Host requirements: 4 CPUs / 8 GB RAM (LALSuite needs this)

### .devcontainer/README.md

Documentation explaining:
- When to use each container
- How to use with VS Code locally
- How to use with GitHub Codespaces
- What's included in each

## Test plan

- [x] devcontainer.json files validated against containers.dev schema
- [x] JSON syntax verified
- [ ] Testing the actual containers requires running VS Code or Codespaces (reviewer can verify)

## Usage

Once merged, contributors can:

1. **VS Code locally**: F1 → Dev Containers: Reopen in Container → choose core or GW
2. **Codespaces**: Click the green Code button → Codespaces → Create codespace

Both paths give a fully working bilby development environment in minutes without polluting the host system.

## References

- https://containers.dev/ (Dev Container spec)
- https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers