### PR TITLE
feat(emcee): implement get_expected_outputs (closes #804)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The original MRs are only visible on the [LIGO GitLab repository](https://git.li
 
 ## [Unreleased]
 
+### Fixes
+* Implemented `get_expected_outputs` for the `Emcee` sampler, which now correctly reports the `chain.dat` and `sampler.pickle` files it writes to the run directory (closes #804)
+
 ## [2.7.1]
 
 ### Fixes

--- a/bilby/core/sampler/emcee.py
+++ b/bilby/core/sampler/emcee.py
@@ -439,3 +439,39 @@ class Emcee(MCMCSampler):
         self.result.log_prior_evaluations = log_priors
         self.result.log_evidence = np.nan
         self.result.log_evidence_err = np.nan
+
+    @classmethod
+    def get_expected_outputs(cls, outdir=None, label=None):
+        """Get lists of the expected outputs directories and files.
+
+        These are used by :code:`bilby_pipe` when transferring files via HTCondor.
+        The emcee sampler writes its checkpoint information (the serialised
+        sampler and the tab-separated chain history) inside a per-run
+        subdirectory ``{outdir}/emcee_{label}/``. The files written there are:
+
+        - ``chain.dat``: tab-separated chain history, one row per step per
+          walker, updated incrementally as the sampler runs.
+        - ``sampler.pickle``: a dill-pickled copy of the
+          :class:`emcee.EnsembleSampler` instance, used to resume from the
+          last completed step.
+
+        Parameters
+        ----------
+        outdir : str
+            The output directory.
+        label : str
+            The label for the run.
+
+        Returns
+        -------
+        list
+            List of file names produced by the sampler.
+        list
+            List of directory names produced by the sampler.
+        """
+        run_dir = os.path.join(outdir, f"emcee_{label}")
+        filenames = [
+            os.path.join(run_dir, "chain.dat"),
+            os.path.join(run_dir, "sampler.pickle"),
+        ]
+        return filenames, [run_dir]

--- a/test/core/sampler/emcee_test.py
+++ b/test/core/sampler/emcee_test.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 import bilby
@@ -69,6 +70,20 @@ class TestEmcee(unittest.TestCase):
             new_kwargs[equiv] = 100
             self.sampler.kwargs = new_kwargs
             self.assertDictEqual(expected, self.sampler.kwargs)
+
+
+def test_get_expected_outputs():
+    label = "par0"
+    outdir = os.path.join("some", "bilby_pipe", "dir")
+    filenames, directories = bilby.core.sampler.emcee.Emcee.get_expected_outputs(
+        outdir=outdir, label=label
+    )
+    assert len(filenames) == 2
+    assert len(directories) == 1
+    run_dir = os.path.join(outdir, f"emcee_{label}")
+    assert run_dir in directories
+    assert os.path.join(run_dir, "chain.dat") in filenames
+    assert os.path.join(run_dir, "sampler.pickle") in filenames
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements a concrete \`get_expected_outputs\` override for the \`Emcee\` sampler so that \`bilby_pipe\` knows about the \`chain.dat\` and \`sampler.pickle\` files it writes when using HTCondor file transfer.

Closes #804.

## Background

From the issue:

> \`get_expected_outputs\` for \`emcee\` was implemented based on the existing code in \`bilby_pipe\` but it should be updated to include \`chains.dat\` and \`sampler.pickle\`.

Looking at \`bilby/core/sampler/emcee.py\` the checkpoint logic is very explicit about what files get written:

\`\`\`python
chain_file = os.path.join(out_dir, \"chain.dat\")
sampler_file = os.path.join(out_dir, \"sampler.pickle\")
\`\`\`

But \`get_expected_outputs\` was not overridden on \`Emcee\`, so it was falling back to the generic \`Sampler.get_expected_outputs\` which returns only a directory with no files. This means \`bilby_pipe\` was not listing these files as expected outputs for HTCondor transfer.

## Changes

### \`bilby/core/sampler/emcee.py\`

Added a classmethod \`get_expected_outputs\` that returns:
- **Files**: \`{outdir}/emcee_{label}/chain.dat\` and \`{outdir}/emcee_{label}/sampler.pickle\`
- **Directories**: \`{outdir}/emcee_{label}/\`

The implementation follows the same pattern used by the existing \`ptemcee\`, \`dynesty\`, and \`nessai\` overrides.

### \`test/core/sampler/emcee_test.py\`

Added \`test_get_expected_outputs\` following the pattern of the corresponding tests in \`dynesty_test.py\` and \`nessai_test.py\`. It verifies:
- Exactly 2 files are reported
- Exactly 1 directory is reported
- The directory path is \`{outdir}/emcee_{label}\`
- Both expected files (\`chain.dat\`, \`sampler.pickle\`) are in the list

## Test plan

- [x] \`py_compile\` passes for modified files
- [x] New unit test added
- [ ] Full test suite should pass in CI (reviewer to confirm)

## References

Issue reported by @michael-williams (GitLab migration) — original comment at \`bilby/core/sampler/emcee.py#L258\`.