### PR TITLE
feat(plot): add exclude_keys to filter trace plots (closes #730)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The original MRs are only visible on the [LIGO GitLab repository](https://git.li
 
 ## [Unreleased]
 
+### Additions
+* Added `exclude_keys` parameter to `bilby.bilby_mcmc.chain.Chain.plot` and a corresponding `plot_exclude_keys` kwarg on the `Bilby_MCMC` sampler. Accepts glob-style patterns (e.g. `["recalib_*"]`) to filter out nuisance parameters from trace plots, avoiding memory issues with high-dimensional calibration runs (closes #730)
+
 ## [2.7.1]
 
 ### Fixes

--- a/bilby/bilby_mcmc/chain.py
+++ b/bilby/bilby_mcmc/chain.py
@@ -361,11 +361,58 @@ class Chain(object):
         samples = self._chain_array[self.minimum_index : self.position : self.thin]
         return pd.DataFrame(samples, columns=self.keys)
 
-    def plot(self, outdir=".", label="label", priors=None, all_samples=None):
+    def plot(
+        self,
+        outdir=".",
+        label="label",
+        priors=None,
+        all_samples=None,
+        exclude_keys=None,
+    ):
+        """Generate the checkpoint trace plot for this chain.
+
+        Parameters
+        ----------
+        outdir : str
+            Output directory for the generated figure.
+        label : str
+            Run label, used in the output filename.
+        priors : bilby.core.prior.PriorDict, optional
+            Priors used to look up LaTeX labels for each parameter.
+        all_samples : dict or pandas.DataFrame, optional
+            Reference samples to overlay on the histograms (e.g. the
+            combined posterior across all parallel chains).
+        exclude_keys : list of str, optional
+            List of glob-style patterns matching parameter keys to omit
+            from the trace plot. Useful to skip nuisance parameters with
+            many degrees of freedom (e.g. ``recalib_*`` calibration
+            nodes, which can balloon the figure to tens of axes and
+            cause memory issues for long runs). Uses :mod:`fnmatch`
+            semantics, so wildcards like ``*`` and ``?`` are supported.
+            Defaults to ``None`` (plot every key).
+
+            Example::
+
+                chain.plot(exclude_keys=["recalib_*"])
+
+            This matches the spirit of arviz's ``var_names`` /
+            ``filter_vars`` selection for trace plots.
+        """
+        import fnmatch
         import matplotlib.pyplot as plt
 
+        # Filter out excluded keys before computing plot layout
+        if exclude_keys:
+            def _is_excluded(key):
+                return any(fnmatch.fnmatchcase(key, pattern) for pattern in exclude_keys)
+
+            plot_keys = [k for k in self.keys if not _is_excluded(k)]
+        else:
+            plot_keys = list(self.keys)
+
+        n_plot = len(plot_keys)
         fig, axes = plt.subplots(
-            nrows=self.ndim + 3, ncols=2, figsize=(8, 9 + 3 * (self.ndim))
+            nrows=n_plot + 3, ncols=2, figsize=(8, 9 + 3 * n_plot)
         )
         scatter_kwargs = dict(
             lw=0,
@@ -387,7 +434,7 @@ class Chain(object):
 
         # Plot the traceplots
         for (start, stop, thin, color, alpha, ms) in plot_setups:
-            for ax, key in zip(axes[:, 0], self.keys):
+            for ax, key in zip(axes[:, 0], plot_keys):
                 xx = position_indexes[start:stop:thin] / K
                 yy = self.get_1d_array(key)[start:stop:thin]
 
@@ -411,7 +458,7 @@ class Chain(object):
                     ax.set_title(msg)
 
         # Plot the histograms
-        for ax, key in zip(axes[:, 1], self.keys):
+        for ax, key in zip(axes[:, 1], plot_keys):
             if all_samples is not None:
                 yy_all = all_samples[key]
                 if np.any(np.isinf(yy_all)):

--- a/bilby/bilby_mcmc/sampler.py
+++ b/bilby/bilby_mcmc/sampler.py
@@ -182,8 +182,21 @@ class Bilby_MCMC(MCMCSampler):
         exit_code=130,
         verbose=True,
         normalize_prior=True,
+        plot_exclude_keys=None,
         **kwargs,
     ):
+        """
+        Additional parameters
+        ---------------------
+        plot_exclude_keys : list of str, optional
+            Glob-style patterns identifying parameter keys to omit from
+            the checkpoint trace plot. Useful for skipping nuisance
+            parameters with many dimensions (e.g. ``recalib_*``
+            calibration nodes), which can balloon the trace plot figure
+            to dozens of axes and cause memory errors on long runs.
+            Example: ``plot_exclude_keys=["recalib_*"]``. Defaults to
+            ``None`` (plot all keys).
+        """
 
         super(Bilby_MCMC, self).__init__(
             likelihood=likelihood,
@@ -198,6 +211,7 @@ class Bilby_MCMC(MCMCSampler):
 
         self.check_point_plot = check_point_plot
         self.diagnostic = diagnostic
+        self.plot_exclude_keys = plot_exclude_keys
         self.kwargs["target_nsamples"] = self.kwargs["nsamples"]
         self.L1steps = self.kwargs["L1steps"]
         self.L2steps = self.kwargs["L2steps"]
@@ -450,7 +464,12 @@ class Bilby_MCMC(MCMCSampler):
             self.print_ensemble_acceptance()
         if self.check_point_plot:
             self.plot_progress(
-                self.ptsampler, self.label, self.outdir, self.priors, self.diagnostic
+                self.ptsampler,
+                self.label,
+                self.outdir,
+                self.priors,
+                self.diagnostic,
+                exclude_keys=self.plot_exclude_keys,
             )
             self.ptsampler.compute_evidence(
                 outdir=self.outdir, label=self.label, make_plots=True
@@ -545,7 +564,28 @@ class Bilby_MCMC(MCMCSampler):
         logger.info(msg)
 
     @staticmethod
-    def plot_progress(ptsampler, label, outdir, priors, diagnostic=False):
+    def plot_progress(
+        ptsampler, label, outdir, priors, diagnostic=False, exclude_keys=None
+    ):
+        """Create diagnostic checkpoint plots for every sub-sampler.
+
+        Parameters
+        ----------
+        ptsampler :
+            The parallel-tempered sampler whose chains will be plotted.
+        label : str
+            Base label for the output filenames.
+        outdir : str
+            Output directory for the plots.
+        priors : bilby.core.prior.PriorDict
+            Priors for parameter label lookup.
+        diagnostic : bool, optional
+            If ``True``, also emit plots for non-temperature-1 walkers.
+        exclude_keys : list of str, optional
+            Glob-style patterns for parameter keys to skip in the trace
+            plots (e.g. ``["recalib_*"]``). See
+            :meth:`bilby.bilby_mcmc.chain.Chain.plot` for details.
+        """
         logger.info("Creating diagnostic plots")
         for ii, row in ptsampler.sampler_dictionary.items():
             for jj, sampler in enumerate(row):
@@ -556,6 +596,7 @@ class Bilby_MCMC(MCMCSampler):
                         label=plot_label,
                         priors=priors,
                         all_samples=ptsampler.samples,
+                        exclude_keys=exclude_keys,
                     )
 
     @classmethod


### PR DESCRIPTION
## Summary

Addresses #730 by adding an opt-in way to filter nuisance parameters out of the checkpoint trace plots produced by \`bilby_mcmc\`. The motivation in the issue is that with ~20 calibration parameters per detector, trace plots can easily hit 60+ axes and blow up memory on long runs.

Closes #730.

## Design

Rather than hard-removing calibration parameters (which @ColmTalbot correctly pointed out can still be diagnostically useful), this is opt-in with glob-style patterns, matching the spirit of arviz's [\`var_names\` / \`filter_vars\`](https://python.arviz.org/en/stable/api/generated/arviz.plot_trace.html) selection.

\`\`\`python
bilby.run_sampler(
    sampler=\"bilby_mcmc\",
    plot_exclude_keys=[\"recalib_*\"],
    ...
)
\`\`\`

## Changes

### \`bilby/bilby_mcmc/chain.py\`
- Added \`exclude_keys\` parameter to \`Chain.plot()\`
- Uses \`fnmatch.fnmatchcase\` for glob-style pattern matching
- Filters \`self.keys\` before computing the figure layout (so the figure height shrinks with the filtered count)
- Applied to both trace axes and histogram axes
- Added comprehensive docstring with the full parameter list

### \`bilby/bilby_mcmc/sampler.py\`
- Added \`plot_exclude_keys\` kwarg to \`Bilby_MCMC.__init__\`
- Stored as \`self.plot_exclude_keys\`
- Threaded through \`print_long_progress\` → \`plot_progress\` → \`chain.plot\`
- \`plot_progress\` signature extended with \`exclude_keys=None\`

### Backwards compatibility
- Default behaviour is **unchanged** (\`exclude_keys=None\` plots everything)
- Existing users see identical output unless they opt in

## Future work (not in this PR)

The dynesty sampler's trace plotting is generated via dynesty's own machinery and would need a separate adapter to accept \`exclude_keys\`. Happy to follow up in a separate PR once this approach is approved.

## Test plan

- [x] \`py_compile\` passes for both modified files
- [x] \`fnmatch\` patterns work for typical cases (\`recalib_*\`, \`spin_?\`)
- [ ] Full test suite in CI (reviewer to confirm)

## References

- Issue #730 — original report by @gregory.ashton
- arviz trace plot API: https://python.arviz.org/en/stable/api/generated/arviz.plot_trace.html