### PR TITLE
FEAT: Use nested sampling weights in plot_corner and quantiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The original MRs are only visible on the [LIGO GitLab repository](https://git.li
 
 ## [Unreleased]
 
+### Additions
+* Added an ``use_nested_samples`` option to ``Result.plot_corner`` which uses the
+  weighted nested samples rather than the resampled posterior, reducing Monte-Carlo
+  noise in the marginal distributions. ``Result.get_one_dimensional_median_and_error_bar``
+  now also accepts ``samples`` and ``weights`` arguments for weighted quantiles.
+  (closes https://github.com/bilby-dev/bilby/issues/563)
+
 ## [2.7.1]
 
 ### Fixes

--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -296,6 +296,44 @@ def get_weights_for_reweighting(
     return ln_weights, new_log_likelihood_array, new_log_prior_array, old_log_likelihood_array, old_log_prior_array
 
 
+def _weighted_quantile(values, quantiles, weights=None):
+    """ Compute weighted quantiles of a 1D array of samples.
+
+    This uses the "Type 4" definition of a weighted quantile (linear
+    interpolation of the empirical cdf) so that calling with uniform weights
+    reproduces ``numpy.percentile`` to within floating-point precision.
+
+    Parameters
+    ==========
+    values: array_like
+        The sample values.
+    quantiles: array_like
+        The quantiles to compute, in the range ``[0, 1]``.
+    weights: array_like, optional
+        Sample weights. If not provided, uniform weights are used.
+
+    Returns
+    =======
+    numpy.ndarray
+        The weighted quantiles, with the same shape as ``quantiles``.
+    """
+    values = np.asarray(values)
+    quantiles = np.asarray(quantiles)
+    if np.any(quantiles < 0) or np.any(quantiles > 1):
+        raise ValueError("quantiles must be in the range [0, 1]")
+    if weights is None:
+        weights = np.ones_like(values)
+    weights = np.asarray(weights)
+    if values.shape != weights.shape:
+        raise ValueError("values and weights must have the same shape")
+    sorter = np.argsort(values)
+    values = values[sorter]
+    weights = weights[sorter]
+    cumulative = np.cumsum(weights) - 0.5 * weights
+    cumulative /= np.sum(weights)
+    return np.interp(quantiles, cumulative, values)
+
+
 def rejection_sample(posterior, weights):
     """ Perform rejection sampling on a posterior using weights
 
@@ -1022,7 +1060,8 @@ class Result(object):
                     np.mean(self.posterior['log_likelihood'])**2)
 
     def get_one_dimensional_median_and_error_bar(self, key, fmt='.2f',
-                                                 quantiles=(0.16, 0.84)):
+                                                 quantiles=(0.16, 0.84),
+                                                 samples=None, weights=None):
         """ Calculate the median and error bar for a given key
 
         Parameters
@@ -1034,6 +1073,14 @@ class Result(object):
         quantiles: list, tuple
             A length-2 tuple of the lower and upper-quantiles to calculate
             the errors bars for.
+        samples: pandas.DataFrame, optional
+            If provided, compute the quantiles from this data frame instead of
+            ``self.posterior``. Useful to compute statistics from the nested
+            samples with associated ``weights``.
+        weights: array_like, optional
+            If provided, compute weighted quantiles using these weights. Must
+            have the same length as ``samples[key]`` (or ``self.posterior[key]``
+            if ``samples`` is not given).
 
         Returns
         =======
@@ -1047,7 +1094,14 @@ class Result(object):
             raise ValueError("quantiles must be of length 2")
 
         quants_to_compute = np.array([quantiles[0], 0.5, quantiles[1]])
-        quants = np.percentile(self.posterior[key], quants_to_compute * 100)
+        if samples is None:
+            samples = self.posterior
+        values = np.asarray(samples[key])
+        if weights is None:
+            quants = np.percentile(values, quants_to_compute * 100)
+        else:
+            quants = _weighted_quantile(
+                values, quants_to_compute, weights=np.asarray(weights))
         summary.median = quants[1]
         summary.plus = quants[2] - summary.median
         summary.minus = summary.median - quants[0]
@@ -1227,7 +1281,7 @@ class Result(object):
 
     @latex_plot_format
     def plot_corner(self, parameters=None, priors=None, titles=True, save=True,
-                    filename=None, dpi=300, **kwargs):
+                    filename=None, dpi=300, use_nested_samples=False, **kwargs):
         """ Plot a corner-plot
 
         Parameters
@@ -1250,6 +1304,13 @@ class Result(object):
             If given, overwrite the default filename
         dpi: int, optional
             Dots per inch resolution of the plot
+        use_nested_samples: bool, optional
+            If true, use the weighted nested samples rather than the
+            resampled posterior. This is only available for results produced
+            by nested samplers and can produce smoother marginal distributions
+            by avoiding the Monte-Carlo noise from resampling. When enabled,
+            weights are passed through to ``corner.corner`` and to the title
+            quantile computation. Defaults to False.
         **kwargs:
             Other keyword arguments are passed to `corner.corner`. We set some
             defaults to improve the basic look and feel, but these can all be
@@ -1363,8 +1424,29 @@ class Result(object):
         if isinstance(kwargs.get('truths'), bool):
             kwargs.pop('truths')
 
-        # Create the data array to plot and pass everything to corner
-        xs = self.posterior[plot_parameter_keys].values
+        # Create the data array to plot and pass everything to corner.
+        # Optionally use the weighted nested samples instead of the
+        # resampled posterior to reduce Monte-Carlo noise in the marginals.
+        ns_weights = None
+        if use_nested_samples:
+            if self._nested_samples is None:
+                raise ValueError(
+                    "use_nested_samples=True but this result has no "
+                    "nested_samples attribute (not a nested-sampling run).")
+            if "weights" not in self.nested_samples.columns:
+                raise ValueError(
+                    "use_nested_samples=True but the nested_samples data "
+                    "frame does not contain a 'weights' column.")
+            samples_df = self.nested_samples
+            ns_weights = np.asarray(self.nested_samples["weights"])
+            xs = samples_df[plot_parameter_keys].values
+            kwargs["weights"] = ns_weights
+            hist_kwargs_defaults["weights"] = ns_weights
+            kwargs["hist_kwargs"] = hist_kwargs_defaults
+        else:
+            samples_df = self.posterior
+            xs = samples_df[plot_parameter_keys].values
+
         if len(plot_parameter_keys) > 1:
             fig = corner.corner(xs, **kwargs)
         else:
@@ -1382,7 +1464,8 @@ class Result(object):
                 ax = axes[i + i * len(plot_parameter_keys)]
                 if ax.title.get_text() == '':
                     ax.set_title(self.get_one_dimensional_median_and_error_bar(
-                        par, quantiles=kwargs['quantiles']).string,
+                        par, quantiles=kwargs['quantiles'],
+                        samples=samples_df, weights=ns_weights).string,
                         **kwargs['title_kwargs'])
 
         #  Add priors to the 1D plots

--- a/test/core/result_test.py
+++ b/test/core/result_test.py
@@ -464,6 +464,69 @@ class TestResult(unittest.TestCase):
         self.result.plot_corner(parameters=["x", "y"], truths=[1, 1])
         self.result.plot_corner(parameters=dict(x=1, y=1))
 
+    def test_plot_corner_use_nested_samples(self):
+        n = 200
+        nested_samples = pd.DataFrame(
+            dict(
+                x=np.random.normal(0, 1, n),
+                y=np.random.normal(0, 1, n),
+                weights=np.random.uniform(0, 1, n),
+            )
+        )
+        self.result.nested_samples = nested_samples
+        self.result.plot_corner(use_nested_samples=True)
+        self.result.plot_corner(
+            parameters=["x", "y"], use_nested_samples=True)
+
+    def test_plot_corner_use_nested_samples_no_nested_samples(self):
+        self.result.nested_samples = None
+        with self.assertRaises(ValueError):
+            self.result.plot_corner(use_nested_samples=True)
+
+    def test_plot_corner_use_nested_samples_no_weights_column(self):
+        self.result.nested_samples = pd.DataFrame(
+            dict(x=np.random.normal(0, 1, 50), y=np.random.normal(0, 1, 50))
+        )
+        with self.assertRaises(ValueError):
+            self.result.plot_corner(use_nested_samples=True)
+
+    def test_weighted_quantile_uniform_matches_percentile(self):
+        values = np.random.normal(0, 1, 1000)
+        quantiles = np.array([0.16, 0.5, 0.84])
+        weighted = bilby.core.result._weighted_quantile(
+            values, quantiles, weights=np.ones_like(values))
+        unweighted = np.percentile(values, quantiles * 100)
+        np.testing.assert_allclose(weighted, unweighted, atol=1e-6)
+
+    def test_weighted_quantile_constant_weights(self):
+        values = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        quantiles = np.array([0.0, 0.5, 1.0])
+        weighted = bilby.core.result._weighted_quantile(
+            values, quantiles, weights=np.full_like(values, 2.0))
+        np.testing.assert_allclose(weighted, [1.0, 3.0, 5.0])
+
+    def test_weighted_quantile_invalid_quantiles(self):
+        with self.assertRaises(ValueError):
+            bilby.core.result._weighted_quantile(
+                np.array([1.0, 2.0]), np.array([-0.1, 1.1]))
+
+    def test_weighted_quantile_mismatched_shapes(self):
+        with self.assertRaises(ValueError):
+            bilby.core.result._weighted_quantile(
+                np.array([1.0, 2.0, 3.0]),
+                np.array([0.5]),
+                weights=np.array([1.0, 1.0]))
+
+    def test_get_one_dimensional_median_and_error_bar_weights(self):
+        n = 500
+        samples = pd.DataFrame(
+            dict(x=np.random.normal(0, 1, n)))
+        weights = np.ones(n)
+        summary = self.result.get_one_dimensional_median_and_error_bar(
+            "x", samples=samples, weights=weights)
+        unweighted_median = np.percentile(samples["x"], 50)
+        self.assertAlmostEqual(summary.median, unweighted_median, places=6)
+
     def test_plot_corner_with_priors(self):
         priors = bilby.core.prior.PriorDict()
         priors["x"] = bilby.core.prior.Uniform(-1, 1, "x")


### PR DESCRIPTION
## Summary

Closes #563.

- Adds a new `use_nested_samples` keyword to `Result.plot_corner`. When enabled, the full nested-sampling chain is passed to `corner.corner` along with the per-sample `weights` column, rather than using the resampled posterior. This avoids the Monte-Carlo tail noise introduced by resampling and produces smoother marginal distributions.
- Extends `Result.get_one_dimensional_median_and_error_bar` with optional `samples` and `weights` arguments so the 1D title quantiles can be computed from the same weighted samples that are plotted.
- Adds a `_weighted_quantile` helper that computes quantiles via linear interpolation of the weighted empirical CDF. With uniform weights it reproduces `numpy.percentile` to within floating-point precision.

Raises a clear `ValueError` when `use_nested_samples=True` is passed but the result has no nested samples or no `weights` column in the nested samples data frame.

## Test plan
- [x] Added `test_plot_corner_use_nested_samples` covering successful use.
- [x] Added error-path tests when nested samples are absent or lack a `weights` column.
- [x] Added unit tests for `_weighted_quantile` (uniform weights match `np.percentile`, edge cases, shape validation).
- [x] Added test verifying `get_one_dimensional_median_and_error_bar` accepts `samples`/`weights` and returns sensible medians.
- [ ] CI green on the bilby-dev CI.