### PR TITLE
TEST: Wire docstring doctests into the unittest suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The original MRs are only visible on the [LIGO GitLab repository](https://git.li
 
 ## [Unreleased]
 
+### Additions
+* Wired docstring examples into the unit-test suite via
+  ``test/core/doctest_test.py``. Doctests are now discovered automatically
+  through the unittest ``load_tests`` protocol for any module listed in
+  ``MODULES_WITH_DOCTESTS``. Converted the existing example in
+  ``bilby.core.utils.introspection`` into a real doctest, and documented
+  the workflow for adding new doctests in ``CONTRIBUTING.md``.
+  (closes https://github.com/bilby-dev/bilby/issues/473)
+
 ## [2.7.1]
 
 ### Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,33 @@ class TestFFT(unittest.TestCase):
 
 For more information on how to write effective tests, see [this guide](https://docs.python-guide.org/writing/tests/), and many others.
 
+### Doctests
+
+Examples embedded in docstrings can also be executed as part of the test suite
+via Python's built-in [`doctest`](https://docs.python.org/3/library/doctest.html)
+module. To add a doctest, use the standard `>>> ` prompt format (without an
+enclosing `.. code-block:: python` directive, which would hide the example from
+`doctest`):
+
+```python
+def add(a, b):
+    """Return the sum of two numbers.
+
+    Examples
+    ========
+
+    >>> add(2, 3)
+    5
+    """
+    return a + b
+```
+
+Then add the parent module to the `MODULES_WITH_DOCTESTS` list in
+`test/core/doctest_test.py` so that the example is picked up by the unittest
+loader. Only register modules that are safe to import in a minimal environment
+(no LAL, no `gwpy`, no heavyweight samplers), since `doctest_test.py` is run as
+part of the standard test job.
+
 ## Code relevance
 
 The bilby code base is intended to be highly modular and flexible. We encourage

--- a/bilby/core/utils/introspection.py
+++ b/bilby/core/utils/introspection.py
@@ -85,13 +85,10 @@ def infer_args_from_function_except_n_args(func, n=1):
     Examples
     ========
 
-    .. code-block:: python
-
-        >>> def hello(a, b, c, d):
-        >>>     pass
-        >>>
-        >>> infer_args_from_function_except_n_args(hello, 2)
-        ['c', 'd']
+    >>> def hello(a, b, c, d):
+    ...     pass
+    >>> infer_args_from_function_except_n_args(hello, 2)
+    ['c', 'd']
 
     """
     parameters = inspect.getfullargspec(func).args

--- a/test/core/doctest_test.py
+++ b/test/core/doctest_test.py
@@ -1,0 +1,90 @@
+"""Run the :mod:`doctest` examples embedded in bilby docstrings.
+
+This test file wires bilby's docstring examples into the standard
+``unittest`` test suite via :class:`doctest.DocTestSuite`.  Modules are
+added to the suite explicitly rather than via a recursive walk because
+some bilby submodules have heavy optional dependencies (``lalsuite``,
+``gwpy``, ...) that are not guaranteed to be importable in every test
+environment.  When adding a new doctest to bilby, append the parent
+module to :data:`MODULES_WITH_DOCTESTS` below.
+
+The test is discovered by :mod:`pytest` in the usual way, so it runs as
+part of the standard ``pytest test`` invocation, and is also runnable
+directly via ``python -m unittest test.core.doctest_test``.
+"""
+import doctest
+import importlib
+import unittest
+
+
+# Add the importable dotted name of any bilby module that contains
+# doctest-format ``>>>`` examples.  Only list modules that are safe to
+# import in a minimal test environment (no LAL, no gwpy, no samplers).
+MODULES_WITH_DOCTESTS = [
+    "bilby.core.utils.introspection",
+]
+
+
+def load_tests(loader, tests, ignore):
+    """unittest ``load_tests`` protocol hook.
+
+    Collects doctests from every module listed in
+    :data:`MODULES_WITH_DOCTESTS` and appends them to the existing
+    ``TestSuite``.  Modules that fail to import (for example because an
+    optional dependency is missing) are silently skipped so that the
+    bulk of the suite still runs.
+    """
+    for module_name in MODULES_WITH_DOCTESTS:
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            continue
+        try:
+            suite = doctest.DocTestSuite(
+                module,
+                optionflags=(
+                    doctest.ELLIPSIS
+                    | doctest.NORMALIZE_WHITESPACE
+                    | doctest.IGNORE_EXCEPTION_DETAIL
+                ),
+            )
+        except ValueError:
+            # DocTestSuite raises ValueError if the module contains no
+            # doctests at all.  This is not a failure for us — modules
+            # are expected to grow doctests over time.
+            continue
+        tests.addTests(suite)
+    return tests
+
+
+class TestDoctestInfrastructure(unittest.TestCase):
+    """Sanity check that the doctest wiring itself is functional."""
+
+    def test_modules_with_doctests_is_populated(self):
+        self.assertTrue(
+            len(MODULES_WITH_DOCTESTS) > 0,
+            "MODULES_WITH_DOCTESTS should list at least one module so "
+            "that the doctest runner has something to execute.",
+        )
+
+    def test_listed_modules_are_importable(self):
+        for module_name in MODULES_WITH_DOCTESTS:
+            with self.subTest(module=module_name):
+                importlib.import_module(module_name)
+
+    def test_introspection_module_has_at_least_one_doctest(self):
+        from bilby.core.utils import introspection
+
+        finder = doctest.DocTestFinder()
+        found = finder.find(introspection)
+        total_examples = sum(len(t.examples) for t in found)
+        self.assertGreater(
+            total_examples,
+            0,
+            "bilby.core.utils.introspection should contain at least "
+            "one doctest example.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #473.

- Adds `test/core/doctest_test.py` which uses the unittest `load_tests` protocol and `doctest.DocTestSuite` to run docstring examples as part of the standard test job. Modules with doctests are listed explicitly in `MODULES_WITH_DOCTESTS` so the runner does not force-import heavy optional dependencies (LAL, gwpy, samplers) in minimal environments.
- Converts the existing example in `bilby.core.utils.introspection.infer_args_from_function_except_n_args` from a `.. code-block:: python` directive (which `doctest` ignores) into a real doctest-format example, so the new runner has a first test to exercise.
- Documents the workflow for adding new doctests in `CONTRIBUTING.md`.

Rationale: the issue asks for automated discovery of docstring examples and points at the `unittest` + `doctest` integration, so using the `load_tests` hook keeps discovery automatic and integrates cleanly with the existing `pytest test` invocation without requiring `pytest --doctest-modules` (which would force-import every bilby submodule).

## Test plan
- [x] Verified the new doctest format parses and runs with `doctest.DocTestSuite` on a representative module.
- [x] Added sanity-check tests (`TestDoctestInfrastructure`) confirming that `MODULES_WITH_DOCTESTS` is populated, all listed modules import cleanly, and the introspection module reports at least one doctest to the `DocTestFinder`.
- [x] Compiled `test/core/doctest_test.py` with `python -m py_compile`.
- [ ] CI green on bilby-dev CI.