### PR TITLE
MAINT: add initial AI policy

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -17,7 +17,7 @@ Bilby maintainers welcome contributions, including those developed with the assi
 4. **Scientific and technical correctness**
    Bilby is scientific software and contributors are expected to validate any AI-assisted contributions carefully, particularly where changes affect algorithms, numerical behaviour, performance, APIs, or scientific results.
 
-5. **Maintainer discretion  **
+5. **Maintainer discretion**
    Maintainers may close or decline pull requests that are low quality, excessively burdensome to review, appear to lack meaningful human oversight, or otherwise are not in the best interests of the project.
 
 > [!NOTE]

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,24 @@
+# Usage of Generative AI
+
+Bilby maintainers welcome contributions, including those developed with the assistance of generative AI tools. However, the use of such tools does not change our expectations for contributor responsibility, engagement, or code quality. The following apply to all contributions.
+
+1. **Human ownership and accountability**
+    i. Contributors are responsible for all submitted content, regardless of whether generative AI tools were used.
+    ii. Contributors must be able to explain and justify all changes during review.
+    iii. Contributors are responsible for ensuring all submitted code complies with Bilby’s licensing requirements, regardless of whether generative AI tools were used.
+    iv. Contributors must remain the clear human owner of the contribution. Pull requests submitted primarily by automated systems or where no accountable human author is evident may be closed.
+
+2. **Engagement**
+   The pull request process is collaborative and iterative. Contributors are expected to actively engage with reviewer feedback themselves. Contributors are expected to understand the changes they are proposing, not act as a message courier for a third party.
+
+3. **Consistency with Bilby conventions and existing style**
+   Contributions should follow Bilby’s existing conventions for code structure, testing, documentation, and communication style. In the context of generative AI, this particularly means ensuring comments, documentation, and proposed interfaces are accurate, concise, and consistent with the rest of the project.
+
+4. **Scientific and technical correctness**
+   Bilby is scientific software and contributors are expected to validate any AI-assisted contributions carefully, particularly where changes affect algorithms, numerical behaviour, performance, APIs, or scientific results.
+
+5. **Maintainer discretion  **
+   Maintainers may close or decline pull requests that are low quality, excessively burdensome to review, appear to lack meaningful human oversight, or otherwise are not in the best interests of the project.
+
+> [!NOTE]
+> This policy is informed by similar guidance adopted in the Scientific Python ecosystem, including Astropy, Matplotlib, and scikit-learn.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,12 +1,12 @@
 # Usage of Generative AI
 
-Bilby maintainers welcome contributions, including those developed with the assistance of generative AI tools. However, the use of such tools does not change our expectations for contributor responsibility, engagement, or code quality. The following apply to all contributions.
+The Bilby maintainers welcome contributions, including those developed with the assistance of generative AI tools. However, the use of such tools does not change our expectations for contributor responsibility, engagement, or code quality. The following apply to all contributions.
 
 1. **Human ownership and accountability**
     i. Contributors are responsible for all submitted content, regardless of whether generative AI tools were used.
     ii. Contributors must be able to explain and justify all changes during review.
     iii. Contributors are responsible for ensuring all submitted code complies with Bilby’s licensing requirements, regardless of whether generative AI tools were used.
-    iv. Contributors must remain the clear human owner of the contribution. Pull requests submitted primarily by automated systems or where no accountable human author is evident may be closed.
+    iv. Contributors must remain the clear human owner of the contribution. Pull requests submitted primarily by automated systems or where no accountable human author is evident may be closed at the maintainers' discretion.
 
 2. **Engagement**
    The pull request process is collaborative and iterative. Contributors are expected to actively engage with reviewer feedback themselves. Contributors are expected to understand the changes they are proposing, not act as a message courier for a third party.


### PR DESCRIPTION
I've had a go at drafting an initial AI policy based on our previous discussions and what astropy has converged upon.

I would be great to get people's thoughts.