### PR TITLE
FEAT: add option to log dynesty progress to influxdb

### DIFF
--- a/bilby/core/sampler/dynesty.py
+++ b/bilby/core/sampler/dynesty.py
@@ -441,7 +441,9 @@ class Dynesty(NestedSampler):
         nc = results.nc
         bounditer = results.bounditer
         eff = results.eff
-        old_point = {key: val for val, key in zip(results.vstar, self.search_parameter_keys)}
+        old_point = {
+            key: val for val, key in zip(results.vstar, self.search_parameter_keys)
+        }
 
         # Adjusting outputs for printing.
         if delta_logz > 1e6:
@@ -485,6 +487,7 @@ class Dynesty(NestedSampler):
 
         if self.influx_api is not None:
             from influxdb_client import Point
+
             point = (
                 Point("sampler_progress")
                 .tag("run_id", self.label)
@@ -501,10 +504,8 @@ class Dynesty(NestedSampler):
             )
 
             if dlogz is not None:
-                point = (
-                    point
-                    .field("delta_logz", float(delta_logz))
-                    .field("dlogz", float(dlogz))
+                point = point.field("delta_logz", float(delta_logz)).field(
+                    "dlogz", float(dlogz)
                 )
             else:
                 point = point.field("stop_val", float(stop_val))
@@ -883,6 +884,7 @@ class Dynesty(NestedSampler):
         # Check if the file exists and is not empty (empty resume files are created for HTCondor file transfer)
         if os.path.isfile(self.resume_file) and os.stat(self.resume_file).st_size > 0:
             logger.info(f"Reading resume file {self.resume_file}")
+
             with open(self.resume_file, "rb") as file:
                 try:
                     sampler = dill.load(file)
@@ -947,6 +949,8 @@ class Dynesty(NestedSampler):
     def write_current_state_and_exit(self, signum=None, frame=None):
         if self.pbar is not None:
             self.pbar = self.pbar.close()
+        if self.influx_api is not None:
+            self.influx_api.close()
         super(Dynesty, self).write_current_state_and_exit(signum=signum, frame=frame)
 
     def write_current_state(self):

--- a/bilby/core/sampler/dynesty.py
+++ b/bilby/core/sampler/dynesty.py
@@ -19,9 +19,6 @@ from ..utils import (
 )
 from .base_sampler import NestedSampler, Sampler, _SamplingContainer, signal_wrapper
 
-INFLUX_BUCKET = os.environ.get("BILBY_INFLUX_BUCKET", "test-bucket")
-INFLUX_ORG = os.environ.get("BILBY_INFLUX_ORG", "test-org")
-
 def _set_sampling_kwargs(args):
     nact, maxmcmc, proposals, naccept = args
     _SamplingContainer.nact = nact
@@ -230,6 +227,7 @@ class Dynesty(NestedSampler):
         rejection_sample_posterior=True,
         proposals=None,
         influx_api=None,
+        influx_bucket="dynesty",
         **kwargs,
     ):
         self.nact = nact
@@ -238,6 +236,7 @@ class Dynesty(NestedSampler):
         self.proposals = proposals
         self.print_method = print_method
         self.influx_api = influx_api
+        self.influx_bucket = influx_bucket
         self._translate_kwargs(kwargs)
         super(Dynesty, self).__init__(
             likelihood=likelihood,
@@ -514,8 +513,7 @@ class Dynesty(NestedSampler):
             point = point.field("logwt", float(results.logwt))
 
             self.influx_api.write(
-                bucket=INFLUX_BUCKET,
-                org=INFLUX_ORG,
+                bucket=self.influx_bucket,
                 record=point,
             )
 

--- a/bilby/core/sampler/dynesty.py
+++ b/bilby/core/sampler/dynesty.py
@@ -19,6 +19,8 @@ from ..utils import (
 )
 from .base_sampler import NestedSampler, Sampler, _SamplingContainer, signal_wrapper
 
+INFLUX_BUCKET = os.environ.get("BILBY_INFLUX_BUCKET", "test-bucket")
+INFLUX_ORG = os.environ.get("BILBY_INFLUX_ORG", "test-org")
 
 def _set_sampling_kwargs(args):
     nact, maxmcmc, proposals, naccept = args
@@ -227,6 +229,7 @@ class Dynesty(NestedSampler):
         naccept=60,
         rejection_sample_posterior=True,
         proposals=None,
+        influx_api=None,
         **kwargs,
     ):
         self.nact = nact
@@ -234,6 +237,7 @@ class Dynesty(NestedSampler):
         self.maxmcmc = maxmcmc
         self.proposals = proposals
         self.print_method = print_method
+        self.influx_api = influx_api
         self._translate_kwargs(kwargs)
         super(Dynesty, self).__init__(
             likelihood=likelihood,
@@ -437,6 +441,7 @@ class Dynesty(NestedSampler):
         nc = results.nc
         bounditer = results.bounditer
         eff = results.eff
+        old_point = {key: val for val, key in zip(results.vstar, self.search_parameter_keys)}
 
         # Adjusting outputs for printing.
         if delta_logz > 1e6:
@@ -477,6 +482,42 @@ class Dynesty(NestedSampler):
             self.pbar.update(niter - self.pbar.n)
         else:
             print(f"{niter}it [{total_time_str} {string}]", file=sys.stdout, flush=True)
+
+        if self.influx_api is not None:
+            from influxdb_client import Point
+            point = (
+                Point("sampler_progress")
+                .tag("run_id", self.label)
+                .field("niter", int(niter))
+                .field("bounditer", int(bounditer))
+                .field("nc", int(nc))
+                .field("ncall", float(ncall))
+                .field("eff", float(eff))
+                .field("logz", float(logz))
+                .field("logzerr", float(logzerr))
+                .field("loglstar", float(loglstar))
+                .field("logl_max", float(logl_max))
+                .time(datetime.datetime.now(datetime.timezone.utc))
+            )
+
+            if dlogz is not None:
+                point = (
+                    point
+                    .field("delta_logz", float(delta_logz))
+                    .field("dlogz", float(dlogz))
+                )
+            else:
+                point = point.field("stop_val", float(stop_val))
+
+            for key, value in old_point.items():
+                point = point.field(key, value)
+            point = point.field("logwt", float(results.logwt))
+
+            self.influx_api.write(
+                bucket=INFLUX_BUCKET,
+                org=INFLUX_ORG,
+                record=point,
+            )
 
     def _apply_dynesty_boundaries(self, key):
         # The periodic kwargs passed into dynesty allows the parameters to

--- a/bilby/core/sampler/dynesty.py
+++ b/bilby/core/sampler/dynesty.py
@@ -19,6 +19,7 @@ from ..utils import (
 )
 from .base_sampler import NestedSampler, Sampler, _SamplingContainer, signal_wrapper
 
+
 def _set_sampling_kwargs(args):
     nact, maxmcmc, proposals, naccept = args
     _SamplingContainer.nact = nact


### PR DESCRIPTION
I've been experimenting with logging to a timeseries database to enable visualization on, e.g., grafana.
This uploads the printed information plus the current removed point using a user-provided endpoint.

I have an initial version of a test dashboard that essentially reproduces our checkpoint plots in real time using these uploads.

I have an example of how to use this.
It requires some user setup, but this is going to be an advanced option so I'm fine with that.