### PR TITLE
DEP: remove `BILBY_INCLUDE_GLOBAL_META_DATA`

### DIFF
--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -26,7 +26,6 @@ from .utils import (
     recursively_decode_bilby_json,
     safe_file_dump,
     random,
-    string_to_boolean,
 )
 from .prior import Prior, PriorDict, DeltaFunction, ConditionalDeltaFunction
 
@@ -537,18 +536,6 @@ class Result(object):
 
         self.prior_values = None
         self._kde = None
-
-        if not string_to_boolean(os.getenv("BILBY_INCLUDE_GLOBAL_META_DATA", "False")):
-            gmd = self.meta_data.pop("global_meta_data", None)
-            if gmd is not None:
-                logger.info(
-                    "Global meta data was removed from the result object for compatibility. "
-                    "Use the `BILBY_INCLUDE_GLOBAL_METADATA` environment variable to include it. "
-                    "This behaviour will be removed in a future release. "
-                    "For more details see: https://bilby-dev.github.io/bilby/faq.html#global-meta-data"
-                )
-        else:
-            logger.debug("Including global meta data in the result object.")
 
     _load_doctstring = """ Read in a saved .{format} data file
 

--- a/bilby/gw/result.py
+++ b/bilby/gw/result.py
@@ -140,8 +140,6 @@ class CompactBinaryCoalescenceResult(CoreResult):
         """The global cosmology used in the analysis.
 
         Will return None if the result does not include global meta data.
-        Inclusion of the the global meta is controlled by the
-        :code:`BILBY_INCLUDE_GLOBAL_META_DATA` environment variable.
 
         .. versionadded:: 2.5.0
         """

--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -11,22 +11,3 @@ Plotting questions
 which can set up the rcParams and we use environment variables to allow
 configuration of this. See the docstring of this :code:`bilby.core.utils.latex_plot_format`
 for the allowed configuration options.
-
-
-Global meta data
-----------------
-
-**Q:** I'm seeing a message about global meta data, what does this mean?
-
-**A:** In :code:`bilby` 2.5.0, the global meta data dictionary was added to the result object
-under :code:`result.meta_data["global_meta_data]`. This includes information such as the 
-global cosmology and random number generator. To ensure backwards compatibility,
-by default, this dictionary is removed from the result object when it is instantiated.
-In a future release, this will be changed.
-In the meantime, you can include the global meta data by setting the
-global variable :code:`BILBY_INCLUDE_GLOBAL_META_DATA=1`
-(:code:`BILBY_INCLUDE_GLOBAL_META_DATA=0` excludes it).
-This can be either be done in the command line using
-:code:`export BILBY_INCLUDE_GLOBAL_META_DATA=1` or within
-python (e.g. using :code:`os`,
-:code:`os.environ["BILBY_INCLUDE_GLOBAL_META_DATA"] = "1"`)

--- a/test/gw/result_test.py
+++ b/test/gw/result_test.py
@@ -1,5 +1,4 @@
 import os
-import logging
 import unittest
 
 import pandas as pd
@@ -212,43 +211,21 @@ class TestCBCResult(BaseCBCResultTest):
         )
 
 
-@parameterized_class(
-    ["include_global_meta_data"], [["True"], ["False"]]
-)
 class CBCResultsGlobalMetaDataTest(BaseCBCResultTest):
 
     @pytest.fixture(autouse=True)
     def set_caplog(self, caplog):
         self._caplog = caplog
 
-    def setUp(self):
-        # Current default is False
-        self.meta_data_env_var = os.getenv("BILBY_INCLUDE_GLOBAL_META_DATA") or "False"
-        os.environ["BILBY_INCLUDE_GLOBAL_META_DATA"] = self.include_global_meta_data
-        super().setUp()
-
-    def tearDown(self):
-        super().tearDown()
-        os.environ["BILBY_INCLUDE_GLOBAL_META_DATA"] = self.meta_data_env_var
-
     def test_global_meta_data(self):
-        if self.include_global_meta_data == "True":
-            assert "global_meta_data" in self.result.meta_data
-        else:
-            assert "global_meta_data" not in self.result.meta_data
+        assert "global_meta_data" in self.result.meta_data
 
     def test_cosmology(self):
         bilby.core.utils.meta_data.logger.propagate = True
-        with self._caplog.at_level(logging.DEBUG, logger="bilby"):
-            cosmology = self.result.cosmology
-        if self.include_global_meta_data == "True":
-            self.assertEqual(
-                self.result.cosmology,
-                self.meta_data["global_meta_data"]["cosmology"],
-            )
-        else:
-            self.assertEqual(cosmology, None)
-            assert "not containing global meta data" in str(self._caplog.text)
+        self.assertEqual(
+            self.result.cosmology,
+            self.meta_data["global_meta_data"]["cosmology"],
+        )
 
 
 @parameterized_class(


### PR DESCRIPTION
Remove the `BILBY_INCLUDE_GLOBAL_META_DATA` environment variable.

Closes #https://github.com/bilby-dev/bilby/issues/1079