### PR TITLE
ENH: GWSignal disabled parameter warnings

### DIFF
--- a/bilby/gw/waveform_generator.py
+++ b/bilby/gw/waveform_generator.py
@@ -398,6 +398,30 @@ class GWSignalWaveformGenerator(WaveformGenerator):
         output = {key: 0.0 for key in keys}
         return output
 
+    @property
+    def _disabled_parameters(self):
+        disabled = set()
+        if not self.spinning:
+            disabled = disabled.union({"a_1", "a_2", "tilt_1", "tilt_2", "phi_12", "phi_jl"})
+        if not self.eccentric:
+            disabled = disabled.union({"eccentricity", "mean_per_ano"})
+        if not self.tidal:
+            disabled = disabled.union({"lambda_1", "lambda_2"})
+        return disabled
+
+    def _format_parameters(self, parameters):
+        self._warn_about_disabled_parameters(parameters)
+        return super()._format_parameters(parameters)
+
+    def _warn_about_disabled_parameters(self, parameters):
+        diff = set(parameters.keys()).intersection(self._disabled_parameters)
+        if len(diff) > 0:
+            logger.warning(
+                f"The following parameters are set but will be ignored since "
+                f"spinning={self.spinning}, eccentric={self.eccentric} and "
+                f"tidal={self.tidal}: {sorted(diff)}"
+            )
+
     def _from_bilby_parameters(self, **parameters):
         from .conversion import bilby_to_lalsimulation_spins
 

--- a/bilby/gw/waveform_generator.py
+++ b/bilby/gw/waveform_generator.py
@@ -400,14 +400,7 @@ class GWSignalWaveformGenerator(WaveformGenerator):
 
     @property
     def _disabled_parameters(self):
-        disabled = set()
-        if not self.spinning:
-            disabled = disabled.union({"a_1", "a_2", "tilt_1", "tilt_2", "phi_12", "phi_jl"})
-        if not self.eccentric:
-            disabled = disabled.union({"eccentricity", "mean_per_ano"})
-        if not self.tidal:
-            disabled = disabled.union({"lambda_1", "lambda_2"})
-        return disabled
+        return set(self.defaults.keys())
 
     def _format_parameters(self, parameters):
         self._warn_about_disabled_parameters(parameters)

--- a/test/gw/waveform_generator_test.py
+++ b/test/gw/waveform_generator_test.py
@@ -767,6 +767,55 @@ class TestGWSignalGenerator(unittest.TestCase):
         wf_2 = wfg.frequency_domain_strain(parameters_2)
         np.testing.assert_equal(wf_1["plus"], wf_2["plus"])
 
+    def test_warns_for_disabled_eccentric_parameters(self):
+        wfg = self.get_wfgen(eccentric=False, spinning=False, tidal=False)
+        parameters = dict(
+            mass_1=10.0,
+            mass_2=10.0,
+            theta_jn=1.0,
+            luminosity_distance=1.0,
+            phase=0.0,
+            eccentricity=0.1,
+            mean_per_ano=0.2,
+        )
+        with mock.patch.object(bilby.gw.waveform_generator.logger, "warning") as warning:
+            wfg._format_parameters(parameters)
+        warning.assert_called_once_with(
+            "The following parameters are set but will be ignored since "
+            "spinning=False, eccentric=False and tidal=False: ['eccentricity', 'mean_per_ano']"
+        )
+
+    def test_warns_for_disabled_tides(self):
+        wfg = self.get_wfgen(eccentric=False, spinning=False, tidal=False)
+        parameters = dict(
+            mass_1=10.0,
+            mass_2=10.0,
+            theta_jn=1.0,
+            luminosity_distance=1.0,
+            phase=0.0,
+            lambda_1=1000.0,
+            lambda_2=1000.0,
+        )
+        with mock.patch.object(bilby.gw.waveform_generator.logger, "warning") as warning:
+            wfg._format_parameters(parameters)
+        warning.assert_called_once_with(
+            "The following parameters are set but will be ignored since "
+            "spinning=False, eccentric=False and tidal=False: ['lambda_1', 'lambda_2']"
+        )
+
+    def test_does_not_warn_for_unrelated_parameters(self):
+        wfg = self.get_wfgen(eccentric=False, spinning=False, tidal=False)
+        parameters = dict(
+            chirp_mass=10.0,
+            mass_ratio=1.0,
+            theta_jn=1.0,
+            luminosity_distance=1.0,
+            phase=0.0,
+        )
+        with mock.patch.object(bilby.gw.waveform_generator.logger, "warning") as warning:
+            wfg._format_parameters(parameters)
+        warning.assert_not_called()
+
     def test_eccentric_parameters_work(self):
         wfg = self.get_wfgen(
             eccentric=True, spinning=False, waveform_approximant="EccentricFD",


### PR DESCRIPTION
This PR adds warnings to the GWSignal generator that trigger when parameters that are disabled (e.g. when eccentric=False) are specified when calling the generator.

For now, these are just logger warnings but we could change these to an error if we wanted.

Related to #1034 