### PR TITLE
CI: rename latest dynesty job

### DIFF
--- a/.github/workflows/latest-dynesty.yml
+++ b/.github/workflows/latest-dynesty.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   build:
 
-    name: ${{ matrix.python.name }} unit tests
+    name: ${{ matrix.python.name }} latest dynesty
     runs-on: ubuntu-latest
     container: ghcr.io/bilby-dev/bilby-python${{ matrix.python.short-version }}:latest
     strategy:


### PR DESCRIPTION
I realized the test with the latest dynesty main was marked as 'required'  because it shared its name with another. Changing it should mean it can be optional.