### PR TITLE
TYPO: Improve logging for missing priors for marginalized likelihoods

### DIFF
--- a/bilby/gw/likelihood/base.py
+++ b/bilby/gw/likelihood/base.py
@@ -353,9 +353,10 @@ class GravitationalWaveTransient(Likelihood):
             )
         if key not in self.priors or not isinstance(
                 self.priors[key], Prior):
-            logger.warning(
-                'Prior not provided for {}, using the BBH default.'.format(key))
             if key == 'geocent_time':
+                logger.warning(
+                    'Prior not provided for geocent time, using the full segment.'
+                )
                 self.priors[key] = Uniform(
                     self.interferometers.start_time,
                     self.interferometers.start_time + self.interferometers.duration)
@@ -372,6 +373,9 @@ class GravitationalWaveTransient(Likelihood):
                         )
                         del self.priors[key]
             else:
+                logger.warning(
+                    'Prior not provided for {}, using the BBH default.'.format(key)
+                )
                 self.priors[key] = BBHPriorDict()[key]
 
     @property


### PR DESCRIPTION
I noticed that this message is out of place and will lead to confusing messages if people specift a prior over redshift and marginalize.