### PR TITLE
Add warning to PriorDict.evaluate_constraints.

### DIFF
--- a/bilby/core/prior/dict.py
+++ b/bilby/core/prior/dict.py
@@ -55,6 +55,8 @@ class PriorDict(dict):
             self.conversion_function = self.default_conversion_function
 
     def evaluate_constraints(self, sample):
+        if self.conversion_function == self.default_conversion_function and type(self).default_conversion_function == PriorDict.default_conversion_function and any(isinstance(v, Constraint) for v in self.values()):
+            logger.warning("Sampling from prior with Constraints, but no conversion function. The Constraints will be ignored.")
         out_sample = self.conversion_function(sample)
         try:
             prob = np.ones_like(next(iter(out_sample.values())))


### PR DESCRIPTION
Addresses #1098

Technically, if the conversion function does not affect some of the constrained parameters they will be ignored too, but to check this would (afaik) require quite some refactoring and I'm not sure it is worth implementing. 

However, having talked to people that use Bilby, all of them have been surprised and worried by this behaviour, so this warning, which will affect all cases in which a prior is defined without an explicit conversion function, is a good step imo.