### PR TITLE
REL: prepare 2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The original MRs are only visible on the [LIGO GitLab repository](https://git.li
 
 ## [Unreleased]
 
+## [2.8.1]
+
+### Fixes
+
+* BUG: Fix 0-dimensional array in priors by @GregoryAshton in https://github.com/bilby-dev/bilby/pull/1061 and backported in https://github.com/bilby-dev/bilby/pull/1103
+* BUG: Fix typo in interferometer.py to_pickle method by @AlexandreGoettel in https://github.com/bilby-dev/bilby/pull/1081 and backported in https://github.com/bilby-dev/bilby/pull/1103
+
 ## [2.8.0]
 
 This is our last planned minor version increase before Bilby version 3.
@@ -1275,7 +1282,8 @@ First `pip` installable version https://pypi.org/project/BILBY/ .
 - All chainconsumer dependency as this was causing issues.
 
 
-[Unreleased]: https://github.com/bilby-dev/bilby/compare/v2.8.0...main
+[Unreleased]: https://github.com/bilby-dev/bilby/compare/v2.8.1...main
+[2.8.1]: https://github.com/bilby-dev/bilby/compare/v2.8.0...v2.8.1
 [2.8.0]: https://github.com/bilby-dev/bilby/compare/v2.7.1...v2.8.0
 [2.7.1]: https://github.com/bilby-dev/bilby/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/bilby-dev/bilby/compare/v2.6.0...v2.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The original MRs are only visible on the [LIGO GitLab repository](https://git.li
 
 ### Fixes
 
-* BUG: Fix 0-dimensional array in priors by @GregoryAshton in https://github.com/bilby-dev/bilby/pull/1061 and backported in https://github.com/bilby-dev/bilby/pull/1103
+* BUG: Fix 0-dimensional array in priors by @ColmTalbot in https://github.com/bilby-dev/bilby/pull/886 and backported https://github.com/bilby-dev/bilby/pull/1103
 * BUG: Fix typo in interferometer.py to_pickle method by @AlexandreGoettel in https://github.com/bilby-dev/bilby/pull/1081 and backported in https://github.com/bilby-dev/bilby/pull/1103
 
 ## [2.8.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The original MRs are only visible on the [LIGO GitLab repository](https://git.li
 * BUG: Fix 0-dimensional array in priors by @ColmTalbot in https://github.com/bilby-dev/bilby/pull/886 and backported https://github.com/bilby-dev/bilby/pull/1103
 * BUG: Fix typo in interferometer.py to_pickle method by @AlexandreGoettel in https://github.com/bilby-dev/bilby/pull/1081 and backported in https://github.com/bilby-dev/bilby/pull/1103
 
+### Changes
+
+* MAINT: Relax tolerance for log noise evidence comparison by @mattpitkin in https://github.com/bilby-dev/bilby/pull/1087 and backported in https://github.com/bilby-dev/bilby/pull/1103
+
 ## [2.8.0]
 
 This is our last planned minor version increase before Bilby version 3.

--- a/bilby/core/prior/dict.py
+++ b/bilby/core/prior/dict.py
@@ -461,7 +461,7 @@ class PriorDict(dict):
                 sample = self.sample_subset(keys=keys, size=size)
                 is_valid = self.evaluate_constraints(sample)
                 n_tested_samples += 1
-                n_valid_samples += int(is_valid)
+                n_valid_samples += int(np.squeeze(is_valid))
                 check_efficiency(n_tested_samples, n_valid_samples)
                 if is_valid:
                     return sample

--- a/bilby/core/prior/dict.py
+++ b/bilby/core/prior/dict.py
@@ -461,7 +461,7 @@ class PriorDict(dict):
                 sample = self.sample_subset(keys=keys, size=size)
                 is_valid = self.evaluate_constraints(sample)
                 n_tested_samples += 1
-                n_valid_samples += int(np.squeeze(is_valid))
+                n_valid_samples += int(is_valid)
                 check_efficiency(n_tested_samples, n_valid_samples)
                 if is_valid:
                     return sample

--- a/bilby/core/prior/dict.py
+++ b/bilby/core/prior/dict.py
@@ -461,7 +461,7 @@ class PriorDict(dict):
                 sample = self.sample_subset(keys=keys, size=size)
                 is_valid = self.evaluate_constraints(sample)
                 n_tested_samples += 1
-                n_valid_samples += int(is_valid)
+                n_valid_samples += int(is_valid.item())
                 check_efficiency(n_tested_samples, n_valid_samples)
                 if is_valid:
                     return sample

--- a/bilby/core/result.py
+++ b/bilby/core/result.py
@@ -2070,7 +2070,7 @@ class ResultList(list):
         if not np.allclose(
             [res.log_noise_evidence for res in self],
             self[0].log_noise_evidence,
-            atol=1e-8,
+            atol=1e-7,
             rtol=0.0,
             equal_nan=True,
         ):

--- a/bilby/gw/detector/interferometer.py
+++ b/bilby/gw/detector/interferometer.py
@@ -923,7 +923,7 @@ class Interferometer(object):
         format="pickle", extra=".. versionadded:: 1.1.0"
     ))
     def to_pickle(self, outdir="outdir", label=None):
-        utils.check_directory_exists_and_if_not_mkdir('outdir')
+        utils.check_directory_exists_and_if_not_mkdir(outdir)
         filename = self._filename_from_outdir_label_extension(outdir, label, extension="pkl")
         safe_file_dump(self, filename, "dill")
 


### PR DESCRIPTION
Prepare 2.8.1.

This PR back ports bug fixes to the 2.8.x branch.

The fixes are:

- ~~https://github.com/bilby-dev/bilby/pull/1061~~ Fix for #1047 from https://github.com/bilby-dev/bilby/pull/886
- https://github.com/bilby-dev/bilby/pull/1081
- https://github.com/bilby-dev/bilby/pull/1087