### PR TITLE
CI: update container dependencies

### DIFF
--- a/containers/environment.yml
+++ b/containers/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - setuptools
   - setuptools_scm
   - matplotlib
-  - numpy<2.4
+  - numpy
   - scipy
   - pandas
   - astropy

--- a/containers/environment.yml
+++ b/containers/environment.yml
@@ -40,7 +40,7 @@ dependencies:
   - nbsphinx
   - sphinx_rtd_theme
   - sphinx-design
-  - dynesty>3.0.0
+  - dynesty>=3.0.0
   - emcee
   - pytorch
   - pytorch-cpu

--- a/containers/environment.yml
+++ b/containers/environment.yml
@@ -57,6 +57,9 @@ dependencies:
   - glasflow
   - nessai-bilby
   - myst-parser
+  - array-api-compat
+  - array-api-extra
+  - plum-dispatch
   - pip:
     - autodoc
     - ipykernel


### PR DESCRIPTION
Update the container dependencies following #886.

I've opened this from the main repo so we can test the builds.

I also noticed the containers were failing (see e.g. https://github.com/bilby-dev/bilby/actions/runs/28349671788) due to a typo in the dynesty constraint (>3.0.0 rather than >=3.0.0)