### PR TITLE
BUG: fix ROQ likelihood incompatibility with numpy 2.4

### DIFF
--- a/bilby/gw/likelihood/roq.py
+++ b/bilby/gw/likelihood/roq.py
@@ -90,14 +90,22 @@ class ROQGravitationalWaveTransient(GravitationalWaveTransient):
 
     @roq_params.setter
     def roq_params(self, roq_params):
-        if (
-            isinstance(roq_params, np.ndarray)
-            and roq_params.dtype.names is not None
-        ):
+        if roq_params is not None:
+            if not isinstance(roq_params, np.ndarray) or roq_params.dtype.names is None:
+                raise TypeError(
+                    "roq_params must be None or a scalar structured numpy array"
+                )
             if roq_params.ndim != 0:
                 raise ValueError(
                     "roq_params must be a scalar structured array; "
                     f"received shape {roq_params.shape}"
+                )
+            required_fields = {"flow", "fhigh", "seglen"}
+            missing_fields = required_fields.difference(roq_params.dtype.names)
+            if missing_fields:
+                raise ValueError(
+                    "roq_params is missing required fields: "
+                    + ", ".join(sorted(missing_fields))
                 )
         self._roq_params = roq_params
 

--- a/bilby/gw/likelihood/roq.py
+++ b/bilby/gw/likelihood/roq.py
@@ -84,6 +84,23 @@ class ROQGravitationalWaveTransient(GravitationalWaveTransient):
         - e.g., "H1": sample in the time of arrival at H1
 
     """
+    @property
+    def roq_params(self):
+        return self._roq_params
+
+    @roq_params.setter
+    def roq_params(self, roq_params):
+        if (
+            isinstance(roq_params, np.ndarray)
+            and roq_params.dtype.names is not None
+        ):
+            if roq_params.ndim != 0:
+                raise ValueError(
+                    "roq_params must be a scalar structured array; "
+                    f"received shape {roq_params.shape}"
+                )
+        self._roq_params = roq_params
+
     def __init__(
             self, interferometers, waveform_generator, priors,
             weights=None, linear_matrix=None, quadratic_matrix=None,
@@ -96,6 +113,7 @@ class ROQGravitationalWaveTransient(GravitationalWaveTransient):
 
     ):
         self._delta_tc = delta_tc
+        self._roq_params = None
         super(ROQGravitationalWaveTransient, self).__init__(
             interferometers=interferometers,
             waveform_generator=waveform_generator, priors=priors,
@@ -130,17 +148,17 @@ class ROQGravitationalWaveTransient(GravitationalWaveTransient):
             if self.roq_params is None:
                 if is_hdf5_linear:
                     self.roq_params = np.array(
-                        [(linear_matrix['minimum_frequency_hz'][()],
-                          linear_matrix['maximum_frequency_hz'][()],
-                          linear_matrix['duration_s'][()])],
+                        (linear_matrix['minimum_frequency_hz'][()],
+                         linear_matrix['maximum_frequency_hz'][()],
+                         linear_matrix['duration_s'][()]),
                         dtype=[('flow', float), ('fhigh', float), ('seglen', float)]
                     )
                 if is_hdf5_quadratic:
                     if self.roq_params is None:
                         self.roq_params = np.array(
-                            [(quadratic_matrix['minimum_frequency_hz'][()],
-                              quadratic_matrix['maximum_frequency_hz'][()],
-                              quadratic_matrix['duration_s'][()])],
+                            (quadratic_matrix['minimum_frequency_hz'][()],
+                             quadratic_matrix['maximum_frequency_hz'][()],
+                             quadratic_matrix['duration_s'][()]),
                             dtype=[('flow', float), ('fhigh', float), ('seglen', float)]
                         )
                     else:

--- a/test/gw/likelihood_test.py
+++ b/test/gw/likelihood_test.py
@@ -3,6 +3,7 @@ import unittest
 import tempfile
 from functools import cached_property
 from itertools import product
+from unittest import mock
 from parameterized import parameterized
 import pytest
 from copy import deepcopy
@@ -1032,13 +1033,25 @@ class TestCreateROQLikelihood(unittest.TestCase, ROQBasisMixin):
             )
         )
 
-        bilby.gw.likelihood.ROQGravitationalWaveTransient(
+        likelihood = bilby.gw.likelihood.ROQGravitationalWaveTransient(
             interferometers=interferometers,
             priors=priors,
             waveform_generator=search_waveform_generator,
             linear_matrix=f"{self.roq_dir}/{basis_linear}",
             quadratic_matrix=f"{self.roq_dir}/{basis_quadratic}"
         )
+        assert np.asarray(likelihood.roq_params).shape == ()
+
+    def test_roq_params_requires_scalar_structured_array(self):
+        likelihood = mock.Mock()
+        with self.assertRaisesRegex(ValueError, "scalar structured array"):
+            bilby.gw.likelihood.ROQGravitationalWaveTransient.roq_params.fset(
+                likelihood,
+                np.array(
+                    [(20.0, 1024.0, 16.0)],
+                    dtype=[("flow", float), ("fhigh", float), ("seglen", float)],
+                ),
+            )
 
     @parameterized.expand([(False, ), (True, )])
     def test_from_npy(self, from_array):

--- a/test/gw/likelihood_test.py
+++ b/test/gw/likelihood_test.py
@@ -1053,6 +1053,17 @@ class TestCreateROQLikelihood(unittest.TestCase, ROQBasisMixin):
                 ),
             )
 
+    def test_roq_params_requires_expected_fields(self):
+        likelihood = mock.Mock()
+        with self.assertRaisesRegex(ValueError, "missing required fields: seglen"):
+            bilby.gw.likelihood.ROQGravitationalWaveTransient.roq_params.fset(
+                likelihood,
+                np.array(
+                    (20.0, 1024.0),
+                    dtype=[("flow", float), ("fhigh", float)],
+                ),
+            )
+
     @parameterized.expand([(False, ), (True, )])
     def test_from_npy(self, from_array):
         basis_linear = f"{self.roq_dir}/B_linear.npy"


### PR DESCRIPTION
The ROQ likelihood had a small bug related to how the HDF5 bases were being loaded that caused an error with numpy 2.4.

I've put in a small fix and make `roq_params` a property so it's shape is checked.