### PR TITLE
DOC: Add 'compat' to the API index

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -56,6 +56,7 @@ API:
    :caption: API:
    :recursive:
 
+    compat
     core
     gw
     hyper


### PR DESCRIPTION
I forgot to add the compat subpackage to the generated API documentation.